### PR TITLE
Properly Implement All Song Filters

### DIFF
--- a/BeatSpiderSharp.CLI/BeatSpiderCLI.cs
+++ b/BeatSpiderSharp.CLI/BeatSpiderCLI.cs
@@ -49,14 +49,29 @@ public class BeatSpiderCLI(bool verbose) : BeatSpider(verbose)
             // allow empty author
             var author = options.PresetAuthor ?? Environment.UserName;
 
-            var p = LegacyPresetLoader.LoadAndConvertLegacyPreset(options.InputPreset, author);
-            if (p == null)
+            try
             {
-                Log.Error("Failed to load preset");
+                var p = LegacyPresetLoader.LoadAndConvertLegacyPreset(options.InputPreset, author);
+                if (p == null)
+                {
+                    Log.Error("Failed to load legacy preset");
+                    return -1;
+                }
+
+                preset = p;
+            }
+            catch (LegacyConversionException e)
+            {
+                Log.Error(e.InnerException, "Failed to convert legacy preset: {Message}", e.Message);
+                Log.Debug(e, "Legacy conversion exception details");
+                return -1;
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Unexpected error while loading legacy preset: {Message}", e.Message);
                 return -1;
             }
 
-            preset = p;
             if (!string.IsNullOrWhiteSpace(options.SaveConvertedPresetPath))
             {
                 Log.Information("Saving converted preset");

--- a/Libs/BeatSpiderSharp.Core/Filters/DetailFilter.cs
+++ b/Libs/BeatSpiderSharp.Core/Filters/DetailFilter.cs
@@ -90,13 +90,13 @@ public class DetailFilter: ISongFilter
 
         if (filter.FullSpread)
         {
-            var pass = diffs
+            var ifFullSpread = diffs
                 .GroupBy(diff => diff.GetMCharacteristic())
                 .Where(group => group.Key is not (null or MCharacteristic.Lightshow))
                 .Any(group =>
                     group.DistinctBy(diff => diff.Difficulty).Count() == Enum.GetValues<MDifficulty>().Length
                 );
-            if (!pass)
+            if (ifFullSpread == filter.FullSpread.Filter)
             {
                 LogExclusion(song, "Not full spread");
                 return false;

--- a/Libs/BeatSpiderSharp.Core/Filters/DetailFilter.cs
+++ b/Libs/BeatSpiderSharp.Core/Filters/DetailFilter.cs
@@ -15,6 +15,10 @@ public class DetailFilter: ISongFilter
     public DetailFilter(DetailOptions options)
     {
         _options = options;
+        if (options.Downloads.Enable || options.Plays.Enable)
+        {
+            throw new Exception("Downloads and Plays filters are not supported as BeatSaver do not keep track of them");
+        }
     }
 
     public bool FilterSong(BeatSpiderSong song)
@@ -96,7 +100,7 @@ public class DetailFilter: ISongFilter
                 .Any(group =>
                     group.DistinctBy(diff => diff.Difficulty).Count() == Enum.GetValues<MDifficulty>().Length
                 );
-            if (ifFullSpread == filter.FullSpread.Filter)
+            if (ifFullSpread != filter.FullSpread.Filter)
             {
                 LogExclusion(song, "Not full spread");
                 return false;
@@ -142,6 +146,15 @@ public class DetailFilter: ISongFilter
             }
         }
 
+        if (filter.AutoMapper)
+        {
+            if (filter.AutoMapper.Filter != map.Automapper)
+            {
+                LogExclusion(song, "Automapper status not matching");
+                return false;
+            }
+        }
+
         if (filter.Bpm && !filter.Bpm.InRange(map.Metadata?.Bpm))
         {
             LogExclusion(song, "BPM not in range");
@@ -154,9 +167,27 @@ public class DetailFilter: ISongFilter
             return false;
         }
 
+        if (filter.Seconds && !diffs.Any(diff => filter.Seconds.InRange(diff.Seconds)))
+        {
+            LogExclusion(song, "Seconds not in range");
+            return false;
+        }
+
+        if (filter.Beats && !diffs.Any(diff => filter.Beats.InRange(diff.Length)))
+        {
+            LogExclusion(song, "Beats not in range");
+            return false;
+        }
+
         if (filter.Njs && !diffs.Any(diff => filter.Njs.InRange(diff.Njs)))
         {
             LogExclusion(song, "NJS not in range");
+            return false;
+        }
+
+        if (filter.Offset && !diffs.Any(diff => filter.Offset.InRange(diff.Offset)))
+        {
+            LogExclusion(song, "Offset not in range");
             return false;
         }
 
@@ -178,6 +209,12 @@ public class DetailFilter: ISongFilter
             return false;
         }
 
+        if (filter.Events && !diffs.Any(diff => filter.Events.InRange(diff.Events)))
+        {
+            LogExclusion(song, "Events not in range");
+            return false;
+        }
+
         if (filter.Walls && !diffs.Any(diff => filter.Walls.InRange(diff.Obstacles)))
         {
             LogExclusion(song, "Walls not in range");
@@ -190,7 +227,7 @@ public class DetailFilter: ISongFilter
             return false;
         }
 
-        if (filter.BeatLeaderRanking && filter.BeatLeaderRanking.SatisfiedBy(map.BlRankingStatus))
+        if (filter.BeatLeaderRanking && !filter.BeatLeaderRanking.SatisfiedBy(map.BlRankingStatus))
         {
             LogExclusion(song, "Required BeatLeader ranking status not found");
             return false;
@@ -214,6 +251,36 @@ public class DetailFilter: ISongFilter
                 LogExclusion(song, "BeatLeader stars not in range");
                 return false;
             }
+        }
+
+        if (filter.ParityErrors && !diffs.Any(diff => filter.ParityErrors.InRange(diff.ParitySummary?.Errors)))
+        {
+            LogExclusion(song, "ParityErrors not in range");
+            return false;
+        }
+
+        if (filter.ParityWarns && !diffs.Any(diff => filter.ParityWarns.InRange(diff.ParitySummary?.Warns)))
+        {
+            LogExclusion(song, "ParityWarns not in range");
+            return false;
+        }
+
+        if (filter.ParityResets && !diffs.Any(diff => filter.ParityResets.InRange(diff.ParitySummary?.Resets)))
+        {
+            LogExclusion(song, "ParityResets not in range");
+            return false;
+        }
+
+        if (filter.SageScore && !filter.SageScore.InRange(latest.SageScore))
+        {
+            LogExclusion(song, "SageScore not in range");
+            return false;
+        }
+
+        if (filter.MaxScore && !diffs.Any(diff => filter.MaxScore.InRange(diff.MaxScore)))
+        {
+            LogExclusion(song, "MaxScore not in range");
+            return false;
         }
 
         // TODO Implement chinese filter

--- a/Libs/BeatSpiderSharp.Core/Filters/LevelDetailFilter.cs
+++ b/Libs/BeatSpiderSharp.Core/Filters/LevelDetailFilter.cs
@@ -1,0 +1,198 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using BeatSpiderSharp.Core.Interfaces;
+using BeatSpiderSharp.Core.Utilities;
+using BeatSpiderSharp.Extensions;
+using BeatSpiderSharp.Models;
+using BeatSpiderSharp.Models.BeatSaver;
+using BeatSpiderSharp.Models.Preset.FilterOptions;
+using Serilog;
+
+namespace BeatSpiderSharp.Core.Filters;
+
+public class LevelDetailFilter(LevelDetailOptions options) : ISongFilter
+{
+    public bool FilterSong(BeatSpiderSong song)
+    {
+        var filter = options;
+        var map = song.BeatSaverSong;
+        var diffs = map.LatestVersion.Diffs;
+
+        // filter levels by Characteristics and Difficulty filter first
+        if (filter.IncludeCharacteristics)
+        {
+            var mapCharas = diffs.Select(diff => diff.GetMCharacteristic()).SelectNotNull().ToHashSet();
+            if (!filter.IncludeCharacteristics.SatisfiedBy(mapCharas))
+            {
+                LogExclusion(song.Bsr, "Required characteristics not found");
+                return false;
+            }
+
+            if (filter.IncludeCharacteristics.Filter.Count > 0)
+            {
+                diffs = diffs.Where(diff =>
+                {
+                    var mapChara = diff.GetMCharacteristic();
+                    return mapChara.HasValue && filter.IncludeCharacteristics.Filter.Contains(mapChara.Value);
+                }).ToList();
+            }
+        }
+
+        if (filter.IncludeDifficulties)
+        {
+            var mapDiffs = diffs.Select(diff => diff.GetMDifficulty()).SelectNotNull().ToHashSet();
+            if (!filter.IncludeDifficulties.SatisfiedBy(mapDiffs))
+            {
+                LogExclusion(song.Bsr,
+                    "Required difficulties not found in the levels satisfying the characteristics filter");
+                return false;
+            }
+
+            if (filter.IncludeDifficulties.Filter.Count > 0)
+            {
+                diffs = diffs.Where(diff =>
+                {
+                    var mapDiff = diff.GetMDifficulty();
+                    return mapDiff.HasValue && filter.IncludeDifficulties.Filter.Contains(mapDiff.Value);
+                }).ToList();
+            }
+        }
+
+        Debug.Assert(diffs.Count > 0, "No difficulties left after chara/diff filter");
+#if DEBUG
+        Log.Verbose("Levels remaining after chara/diff filter: {Levels}", diffs.Count);
+#endif
+
+        var result = diffs.Where(diff => FilterLevel(song.Bsr, diff));
+        //TODO support Playlist diff highlighting
+        if (!result.Any())
+        {
+            LogExclusion(song.Bsr, "No difficulties satisfying the level detail filters");
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool FilterLevel(string bsr, Diff diff)
+    {
+        var filter = options;
+        // Filter the remaining levels
+        if (filter.RequireMods && !filter.RequireMods.SatisfiedBy(diff.GetMMods()))
+        {
+            LogExclusion(bsr, diff, "Required mods not found");
+            return false;
+        }
+
+        if (filter.ExcludeMods && !filter.ExcludeMods.SatisfiedBy(diff.GetMMods()))
+        {
+            LogExclusion(bsr, diff, "Excluded mods found");
+            return false;
+        }
+
+        if (filter.Seconds && !filter.Seconds.InRange(diff.Seconds))
+        {
+            LogExclusion(bsr, diff, "Seconds not in range");
+            return false;
+        }
+
+        if (filter.Beats && !filter.Beats.InRange(diff.Length))
+        {
+            LogExclusion(bsr, diff, "Beats not in range");
+            return false;
+        }
+
+        if (filter.Njs && !filter.Njs.InRange(diff.Njs))
+        {
+            LogExclusion(bsr, diff, "NJS not in range");
+            return false;
+        }
+
+        if (filter.Offset && !filter.Offset.InRange(diff.Offset))
+        {
+            LogExclusion(bsr, diff, "Offset not in range");
+            return false;
+        }
+
+        if (filter.Nps && !filter.Nps.InRange(diff.Nps))
+        {
+            LogExclusion(bsr, diff, "NPS not in range");
+            return false;
+        }
+
+        if (filter.Notes && !filter.Notes.InRange(diff.Notes))
+        {
+            LogExclusion(bsr, diff, "Notes not in range");
+            return false;
+        }
+
+        if (filter.Bombs && !filter.Bombs.InRange(diff.Bombs))
+        {
+            LogExclusion(bsr, diff, "Bombs not in range");
+            return false;
+        }
+
+        if (filter.Events && !filter.Events.InRange(diff.Events))
+        {
+            LogExclusion(bsr, diff, "Events not in range");
+            return false;
+        }
+
+        if (filter.Walls && !filter.Walls.InRange(diff.Obstacles))
+        {
+            LogExclusion(bsr, diff, "Walls not in range");
+            return false;
+        }
+
+        if (filter.ScoreSaberStars && !filter.ScoreSaberStars.InRange(diff.Stars))
+        {
+            LogExclusion(bsr, diff, "ScoreSaber stars not in range");
+            return false;
+        }
+
+        if (filter.BeatLeaderStars && !filter.BeatLeaderStars.InRange(diff.BlStars))
+        {
+            LogExclusion(bsr, diff, "BeatLeader stars not in range");
+            return false;
+        }
+
+        if (filter.ParityErrors && !filter.ParityErrors.InRange(diff.ParitySummary?.Errors))
+        {
+            LogExclusion(bsr, diff, "ParityErrors not in range");
+            return false;
+        }
+
+        if (filter.ParityWarns && !filter.ParityWarns.InRange(diff.ParitySummary?.Warns))
+        {
+            LogExclusion(bsr, diff, "ParityWarns not in range");
+            return false;
+        }
+
+        if (filter.ParityResets && !filter.ParityResets.InRange(diff.ParitySummary?.Resets))
+        {
+            LogExclusion(bsr, diff, "ParityResets not in range");
+            return false;
+        }
+
+        if (filter.MaxScore && !filter.MaxScore.InRange(diff.MaxScore))
+        {
+            LogExclusion(bsr, diff, "MaxScore not in range");
+            return false;
+        }
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void LogExclusion(string bsr, string reason)
+    {
+        Log.Verbose("Song {Bsr} excluded: {Reason}", bsr, reason);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void LogExclusion(string bsr, Diff diff, string reason)
+    {
+        Log.Verbose("Diff {Chara}/{Diff} of Song {Bsr} excluded: {Reason}", diff.Characteristic, diff.Difficulty, bsr,
+            reason);
+    }
+}

--- a/Libs/BeatSpiderSharp.Core/Filters/RootFilter.cs
+++ b/Libs/BeatSpiderSharp.Core/Filters/RootFilter.cs
@@ -8,12 +8,12 @@ public class RootFilter : ISongFilter
 {
     private readonly FilterConfig _config;
 
-    private readonly List<ISongFilter> _filters = new(1); // there is currently only one sub filter existing
+    private readonly List<ISongFilter> _filters;
 
     public RootFilter(FilterConfig config)
     {
         _config = config;
-        _filters.Add(new DetailFilter(_config.DetailFilter));
+        _filters = [new SongDetailFilter(_config.SongDetailFilter), new LevelDetailFilter(_config.LevelDetailOptions)];
     }
 
     public bool FilterSong(BeatSpiderSong song)

--- a/Libs/BeatSpiderSharp.Core/Filters/SongDetailFilter.cs
+++ b/Libs/BeatSpiderSharp.Core/Filters/SongDetailFilter.cs
@@ -1,6 +1,6 @@
-﻿using BeatSpiderSharp.Core.Interfaces;
+﻿using System.Runtime.CompilerServices;
+using BeatSpiderSharp.Core.Interfaces;
 using BeatSpiderSharp.Core.Utilities;
-using BeatSpiderSharp.Extensions;
 using BeatSpiderSharp.Models;
 using BeatSpiderSharp.Models.Enums;
 using BeatSpiderSharp.Models.Preset.FilterOptions;
@@ -8,11 +8,11 @@ using Serilog;
 
 namespace BeatSpiderSharp.Core.Filters;
 
-public class DetailFilter: ISongFilter
+public class SongDetailFilter : ISongFilter
 {
-    private readonly DetailOptions _options;
-    
-    public DetailFilter(DetailOptions options)
+    private readonly SongDetailOptions _options;
+
+    public SongDetailFilter(SongDetailOptions options)
     {
         _options = options;
         if (options.Downloads.Enable || options.Plays.Enable)
@@ -106,45 +106,6 @@ public class DetailFilter: ISongFilter
                 return false;
             }
         }
-        
-        if (filter.IncludeCharacteristics)
-        {
-            var mapCharas = diffs.Select(diff => diff.GetMCharacteristic()).SelectNotNull().ToHashSet();
-            if (!filter.IncludeCharacteristics.SatisfiedBy(mapCharas))
-            {
-                LogExclusion(song, "Required characteristics not found");
-                return false;
-            }
-        }
-        
-        if (filter.IncludeDifficulties)
-        {
-            var mapDiffs = diffs.Select(diff => diff.GetMDifficulty()).SelectNotNull().ToHashSet();
-            if (!filter.IncludeDifficulties.SatisfiedBy(mapDiffs))
-            {
-                LogExclusion(song, "Required difficulties not found");
-                return false;
-            }
-        }
-
-        if (filter.RequireMods)
-        {
-            var pass = diffs.Any(diff => filter.RequireMods.SatisfiedBy(diff.GetMMods()));
-            if (!pass)
-            {
-                LogExclusion(song, "Required mods not found");
-                return false;
-            }
-        }
-        
-        if (filter.ExcludeMods)
-        {
-            if (diffs.All(diff => !filter.ExcludeMods.SatisfiedBy(diff.GetMMods())))
-            {
-                LogExclusion(song, "All difficulties contain excluded mods");
-                return false;
-            }
-        }
 
         if (filter.AutoMapper)
         {
@@ -167,60 +128,6 @@ public class DetailFilter: ISongFilter
             return false;
         }
 
-        if (filter.Seconds && !diffs.Any(diff => filter.Seconds.InRange(diff.Seconds)))
-        {
-            LogExclusion(song, "Seconds not in range");
-            return false;
-        }
-
-        if (filter.Beats && !diffs.Any(diff => filter.Beats.InRange(diff.Length)))
-        {
-            LogExclusion(song, "Beats not in range");
-            return false;
-        }
-
-        if (filter.Njs && !diffs.Any(diff => filter.Njs.InRange(diff.Njs)))
-        {
-            LogExclusion(song, "NJS not in range");
-            return false;
-        }
-
-        if (filter.Offset && !diffs.Any(diff => filter.Offset.InRange(diff.Offset)))
-        {
-            LogExclusion(song, "Offset not in range");
-            return false;
-        }
-
-        if (filter.Nps && !diffs.Any(diff => filter.Nps.InRange(diff.Nps)))
-        {
-            LogExclusion(song, "NPS not in range");
-            return false;
-        }
-
-        if (filter.Notes && !diffs.Any(diff => filter.Notes.InRange(diff.Notes)))
-        {
-            LogExclusion(song, "Notes not in range");
-            return false;
-        }
-
-        if (filter.Bombs && !diffs.Any(diff => filter.Bombs.InRange(diff.Bombs)))
-        {
-            LogExclusion(song, "Bombs not in range");
-            return false;
-        }
-
-        if (filter.Events && !diffs.Any(diff => filter.Events.InRange(diff.Events)))
-        {
-            LogExclusion(song, "Events not in range");
-            return false;
-        }
-
-        if (filter.Walls && !diffs.Any(diff => filter.Walls.InRange(diff.Obstacles)))
-        {
-            LogExclusion(song, "Walls not in range");
-            return false;
-        }
-
         if (filter.ScoreSaberRanking && !filter.ScoreSaberRanking.SatisfiedBy(map.RankingStatus))
         {
             LogExclusion(song, "Required ScoreSaber ranking status not found");
@@ -233,53 +140,9 @@ public class DetailFilter: ISongFilter
             return false;
         }
 
-        if (filter.ScoreSaberStars)
-        {
-            var pass = diffs.Any(diff => filter.ScoreSaberStars.InRange(diff.Stars));
-            if (!pass)
-            {
-                LogExclusion(song, "ScoreSaber stars not in range");
-                return false;
-            }
-        }
-        
-        if (filter.BeatLeaderStars)
-        {
-            var pass = diffs.Any(diff => filter.BeatLeaderStars.InRange(diff.BlStars));
-            if (!pass)
-            {
-                LogExclusion(song, "BeatLeader stars not in range");
-                return false;
-            }
-        }
-
-        if (filter.ParityErrors && !diffs.Any(diff => filter.ParityErrors.InRange(diff.ParitySummary?.Errors)))
-        {
-            LogExclusion(song, "ParityErrors not in range");
-            return false;
-        }
-
-        if (filter.ParityWarns && !diffs.Any(diff => filter.ParityWarns.InRange(diff.ParitySummary?.Warns)))
-        {
-            LogExclusion(song, "ParityWarns not in range");
-            return false;
-        }
-
-        if (filter.ParityResets && !diffs.Any(diff => filter.ParityResets.InRange(diff.ParitySummary?.Resets)))
-        {
-            LogExclusion(song, "ParityResets not in range");
-            return false;
-        }
-
         if (filter.SageScore && !filter.SageScore.InRange(latest.SageScore))
         {
             LogExclusion(song, "SageScore not in range");
-            return false;
-        }
-
-        if (filter.MaxScore && !diffs.Any(diff => filter.MaxScore.InRange(diff.MaxScore)))
-        {
-            LogExclusion(song, "MaxScore not in range");
             return false;
         }
 
@@ -290,7 +153,8 @@ public class DetailFilter: ISongFilter
         // }
         return true;
     }
-    
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void LogExclusion(BeatSpiderSong song, string reason)
     {
         Log.Verbose("Song {Bsr} excluded: {Reason}", song.Bsr, reason);

--- a/Libs/BeatSpiderSharp.Extensions/CollectionExtensions.cs
+++ b/Libs/BeatSpiderSharp.Extensions/CollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿namespace BeatSpiderSharp.Extensions;
+
+public static class CollectionExtensions
+{
+    public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> items)
+    {
+        if (collection is List<T> list)
+        {
+            list.AddRange(items);
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            collection.Add(item);
+        }
+    }
+
+    public static void ReplaceWith<T>(this ICollection<T> collection, IEnumerable<T> items)
+    {
+        collection.Clear();
+        collection.AddRange(items);
+    }
+}

--- a/Libs/BeatSpiderSharp.Legacy/EnumConversions.cs
+++ b/Libs/BeatSpiderSharp.Legacy/EnumConversions.cs
@@ -26,6 +26,7 @@ internal static class EnumConversions
             LegacyPreset.SongFilterSetting.CharacteristicsFilter.SongCharacteristic.ThreeSixtyDegree => MCharacteristic.ThreeSixtyDegree,
             LegacyPreset.SongFilterSetting.CharacteristicsFilter.SongCharacteristic.Lightshow => MCharacteristic.Lightshow,
             LegacyPreset.SongFilterSetting.CharacteristicsFilter.SongCharacteristic.Lawless => MCharacteristic.Lawless,
+            LegacyPreset.SongFilterSetting.CharacteristicsFilter.SongCharacteristic.Legacy => MCharacteristic.Legacy,
             _ => throw new ArgumentOutOfRangeException(nameof(characteristic), characteristic, "Invalid characteristic")
         };
     }

--- a/Libs/BeatSpiderSharp.Legacy/LegacyConversionException.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyConversionException.cs
@@ -1,0 +1,12 @@
+﻿namespace BeatSpiderSharp.Legacy;
+
+public class LegacyConversionException(string message, string? targetName = null, Exception? innerException = null)
+    : Exception(message, innerException)
+{
+    public string? TargetName { get; } = targetName;
+
+    public string BaseMessage => base.Message;
+
+    public override string Message =>
+        string.IsNullOrWhiteSpace(TargetName) ? base.Message : $"{base.Message} (Target: {TargetName})";
+}

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPreset.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPreset.cs
@@ -80,8 +80,14 @@ internal class LegacyPreset
         [JsonProperty("下载方式")]
         public SortType Sort { get; private set; }
 
+        /**
+         * BeatSaver's search API has special logic for this parameter
+         * Disabled: No auto mapped maps
+         * Enabled && True: All maps
+         * Enabled && False: Auto mapped only
+         */
         [JsonProperty("自动生成")]
-        public GeneratedSongSetting GeneratedSong { get; private set; } = new();
+        public AutoMapperSetting AutoMapper { get; private set; } = new();
 
         [JsonProperty("排位曲")]
         public RankedSongSetting RankedSong { get; private set; } = new();
@@ -315,7 +321,7 @@ internal class LegacyPreset
         public MinMaxFloatSetting Rating { get; private set; } = new();
 
         [JsonProperty("自动生成")]
-        public GeneratedSongSetting GeneratedSong { get; private set; } = new();
+        public AutoMapperSetting AutoMapper { get; private set; } = new();
 
         [JsonProperty("排位曲")]
         public RankedSongSetting RankedSong { get; private set; } = new();
@@ -618,14 +624,10 @@ internal class LegacyPreset
         public DateTimeOffset? Max { get; private set; }
     }
 
-    // Original project's settings is weird (but consistent with BeatSaver's API)
-    // Disabled: Human Only
-    // Enabled && True: All
-    // Enabled && False: Generated Only
-    public class GeneratedSongSetting : DisablableSetting
+    public class AutoMapperSetting : DisablableSetting
     {
         [JsonProperty("自动生成")]
-        public bool IncludeGenerated { get; private set; }
+        public bool AutoMapper { get; private set; }
     }
 
     public class RankedSongSetting : DisablableSetting

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -412,7 +412,7 @@ public static partial class LegacyPresetLoader
             UploaderName =
             {
                 Enable = setting.UploaderNames.Enable,
-                Filter = setting.UploaderNames.Content.ToHashSet()
+                Filter = setting.UploaderNames.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase)
             },
             UploadTime = new()
             {
@@ -423,13 +423,13 @@ public static partial class LegacyPresetLoader
             IncludeTags = new()
             {
                 Enable = setting.Tags.Include.Enable,
-                Filter = setting.Tags.Include.Content.ToHashSet(),
+                Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
                 IsOr = !setting.Tags.Include.And
             },
             ExcludeTags =
             {
                 Enable = setting.Tags.Exclude.Enable,
-                Filter = setting.Tags.Exclude.Content.ToHashSet(),
+                Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
                 IsOr = !setting.Tags.Exclude.And
             },
             UpVotes = new()

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -175,7 +175,7 @@ public static class LegacyPresetLoader
             Log.Warning("Play count is not supported");
         }
 
-        if (preset.SongFilter.GeneratedSong.Enable || preset.SongFilter.SageScore.Enable)
+        if (preset.SongFilter.AutoMapper.Enable || preset.SongFilter.SageScore.Enable)
         {
             Log.Warning("AI maps are not supported");
         }
@@ -241,7 +241,7 @@ public static class LegacyPresetLoader
             Log.Warning("BeatSaver search and page number are not supported!");
         }
 
-        if (setting.GeneratedSong.Enable)
+        if (setting.AutoMapper.Enable)
         {
             Log.Warning("AI generated songs are not supported!");
         }

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 using BeatSpiderSharp.Extensions;
 using BeatSpiderSharp.Models.Enums;
 using BeatSpiderSharp.Models.Preset;
@@ -220,7 +221,7 @@ public static class LegacyPresetLoader
         {
             { Enable: false } => (true, false), // no auto mapped 
             { AutoMapper: true } => (false, false), // all maps
-            { AutoMapper: false } => (true, false) // only auto mapped
+            { AutoMapper: false } => (true, true) // only auto mapped
         };
 
         if (options.AutoMapper.Enable && autoMapperEnable && options.AutoMapper.Filter != autoMapperFilter)
@@ -236,15 +237,25 @@ public static class LegacyPresetLoader
             options.AutoMapper.Filter = autoMapperFilter;
         }
 
-        if (setting.RankedSong.Enable && setting.RankedSong.IsRanked)
+        if (setting.RankedSong.Enable)
         {
-            if (options.ScoreSaberRanking.Enable)
+            var states = setting.RankedSong.IsRanked
+                ? new HashSet<RankingStatus> { RankingStatus.Ranked }
+                : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified };
+            if (options.ScoreSaberRanking is { Enable: true, Filter.Count: > 0 })
             {
-                Log.Warning("Overwriting ScoreSaber option to {Status}", RankingStatus.Ranked);
+                states.IntersectWith(options.ScoreSaberRanking.Filter);
+                if (states.Count == 0)
+                {
+                    Log.Error(
+                        "Conflicting ScoreSaber ranked filter. BeatSaver input setting and song filter has no overlap for ScoreSaber ranking status");
+                    throw new LegacyConversionException(
+                        "Conflicting ScoreSaber ranked filter with BeatSaver input setting", "ScoreSaberRanking");
+                }
             }
 
             options.ScoreSaberRanking.Enable = true;
-            options.ScoreSaberRanking.Filter = new HashSet<RankingStatus> { RankingStatus.Ranked };
+            options.ScoreSaberRanking.Filter = states;
         }
 
         options.FullSpread.Enable = setting.Difficulty.Enable;
@@ -280,18 +291,68 @@ public static class LegacyPresetLoader
             CombineRange(options.Rating, setting.Rating, "Rating");
         }
 
-        if (setting.RequireMods.Enable)
+        // mods related is a bit tricky
+        var requireMods = setting.RequireMods.RequireMods.ToMMods();
+        var excludeMods = setting.ExcludeMods.ExcludeMods.ToMMods();
+        if (setting.RequireMods.Enable && setting.ExcludeMods.Enable)
         {
-            options.RequireMods.Enable = true;
-            options.RequireMods.Filter = options.RequireMods.Filter
-                .Concat(setting.RequireMods.RequireMods.ToMMods()).ToHashSet();
+            if (requireMods.Intersect(excludeMods).Any())
+            {
+                Log.Error(
+                    "Conflicting mods requirement. BeatSaver input setting has overlap for required and excluded mods");
+                throw new LegacyConversionException("Conflicting mods requirement in BeatSaver input setting",
+                    "Required/Excluded Mods");
+            }
         }
 
-        if (setting.ExcludeMods.Enable)
+        if (setting.RequireMods.Enable && requireMods.Count > 0)
         {
-            options.ExcludeMods.Enable = true;
-            options.ExcludeMods.Filter = options.ExcludeMods.Filter
-                .Concat(setting.ExcludeMods.ExcludeMods.ToMMods()).ToHashSet();
+            // BeatSaver tests the values as OR
+            if (options.RequireMods && options.RequireMods.Filter.Count > 0)
+            {
+                //Original project only tests this as or
+                Debug.Assert(options.RequireMods.IsOr);
+                if (!options.RequireMods.Filter.SetEquals(requireMods))
+                {
+                    // to achieve this, it needs to AND the results of two OR operations
+                    Log.Error(
+                        "Unsupported mods requirement combination between BeatSaver input setting and song filter setting");
+                    throw new LegacyConversionException(
+                        "Unsupported mods requirement combination between BeatSaver input setting and song filter setting",
+                        "Required Mods");
+                }
+            }
+            else
+            {
+                options.RequireMods.Enable = true;
+                options.RequireMods.IsOr = true;
+                options.RequireMods.Filter.Clear();
+                options.RequireMods.Filter.UnionWith(requireMods);
+            }
+        }
+
+        if (setting.ExcludeMods.Enable && excludeMods.Count > 0)
+        {
+            // BeatSaver tests the values in a very weird way.
+            // If a map doesn't require at least one of the excluded mods, it passes the filter.
+            // As a result, a filter excluding all mods will consider a map requiring one mod satisfying the condition.
+            if (excludeMods.Count != 1)
+            {
+                // no support for this ridiculous logic
+                Log.Error("Unsupported BeatSaver excluded mods setting");
+                throw new LegacyConversionException("Unsupported BeatSaver excluded mods setting", "Excluded Mods");
+            }
+
+            if (options.ExcludeMods)
+            {
+                options.ExcludeMods.Filter.Add(excludeMods.First());
+            }
+            else
+            {
+                options.ExcludeMods.Enable = true;
+                options.ExcludeMods.Filter.Clear();
+                options.ExcludeMods.Filter.Add(excludeMods.First());
+            }
         }
     }
 

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -162,62 +162,13 @@ public static class LegacyPresetLoader
     {
         if (preset.SearchFilter.SearchEnabled)
         {
-            Log.Warning("Search filter is not implemented");
+            //TODO
+            throw new LegacyConversionException("Search filter is not implemented");
         }
         
         if (preset.ThumbnailTag.Enable.Enable)
         {
-            Log.Warning("Thumbnail Tagging is not supported");
-        }
-        
-        if (preset.SongFilter.DownloadCount.Enable)
-        {
-            Log.Warning("Download count is not a thing anymore");
-        }
-        
-        if (preset.SongFilter.PlayCount.Enable)
-        {
-            Log.Warning("Play count is not supported");
-        }
-
-        if (preset.SongFilter.AutoMapper.Enable || preset.SongFilter.SageScore.Enable)
-        {
-            Log.Warning("AI maps are not supported");
-        }
-        
-        if (preset.SongFilter.FilterChinese.Enable)
-        {
-            Log.Warning("Chinese filter is not implemented");
-        }
-
-        if (preset.SongFilter.MapSeconds.Enable)
-        {
-            Log.Warning("Map seconds is not supported");
-        }
-        
-        if (preset.SongFilter.MapLength.Enable)
-        {
-            Log.Warning("Map length is not supported");
-        }
-        
-        if (preset.SongFilter.Offset.Enable)
-        {
-            Log.Warning("Offset is not supported");
-        }
-        
-        if (preset.SongFilter.Events.Enable)
-        {
-            Log.Warning("Events is not supported");
-        }
-        
-        if (preset.SongFilter.ParityErrors.Enable || preset.SongFilter.ParityWarns.Enable || preset.SongFilter.ParityResets.Enable)
-        {
-            Log.Warning("Parity data is not supported");
-        }
-        
-        if (preset.SongFilter.MaxScore.Enable)
-        {
-            Log.Warning("Max score is not supported");
+            throw new LegacyConversionException("Thumbnail Tag is not supported");
         }
     }
 
@@ -264,9 +215,25 @@ public static class LegacyPresetLoader
                 "BeatSaver Search");
         }
 
-        if (setting.AutoMapper.Enable)
+        // following BeatSaver API's handling
+        var (autoMapperEnable, autoMapperFilter) = setting.AutoMapper switch
         {
-            Log.Warning("AI generated songs are not supported!");
+            { Enable: false } => (true, false), // no auto mapped 
+            { AutoMapper: true } => (false, false), // all maps
+            { AutoMapper: false } => (true, false) // only auto mapped
+        };
+
+        if (options.AutoMapper.Enable && autoMapperEnable && options.AutoMapper.Filter != autoMapperFilter)
+        {
+            throw new LegacyConversionException(
+                "Conflicting auto mapper settings from BeatSaver search setting and song filter setting",
+                "AutoMapper");
+        }
+
+        if (autoMapperEnable)
+        {
+            options.AutoMapper.Enable = true;
+            options.AutoMapper.Filter = autoMapperFilter;
         }
 
         if (setting.RankedSong.Enable && setting.RankedSong.IsRanked)
@@ -441,13 +408,30 @@ public static class LegacyPresetLoader
             RequireMods = new()
             {
                 Enable = setting.RequireMods.Enable,
-                Filter = setting.RequireMods.Mods.ToMMods().ToHashSet(),
+                Filter = setting.RequireMods.Mods.ToMMods(),
                 IsOr = true
             },
             ExcludeMods =
             {
                 Enable = setting.ExcludeMods.Enable,
                 Filter = setting.ExcludeMods.Mods.ToMMods()
+            },
+            Downloads =
+            {
+                Enable = setting.DownloadCount.Enable,
+                Min = setting.DownloadCount.Min,
+                Max = setting.DownloadCount.Max
+            },
+            Plays =
+            {
+                Enable = setting.PlayCount.Enable,
+                Min = setting.PlayCount.Min,
+                Max = setting.PlayCount.Max
+            },
+            AutoMapper =
+            {
+                Enable = setting.AutoMapper.Enable,
+                Filter = setting.AutoMapper.AutoMapper
             },
             Bpm = new()
             {
@@ -461,11 +445,29 @@ public static class LegacyPresetLoader
                 Min = setting.Duration.Min,
                 Max = setting.Duration.Max
             },
+            Seconds =
+            {
+                Enable = setting.MapSeconds.Enable,
+                Min = setting.MapSeconds.Min,
+                Max = setting.MapSeconds.Max
+            },
+            Beats =
+            {
+                Enable = setting.MapLength.Enable,
+                Min = setting.MapLength.Min,
+                Max = setting.MapLength.Max
+            },
             Njs = new()
             {
                 Enable = setting.Njs.Enable,
                 Min = setting.Njs.Min,
                 Max = setting.Njs.Max
+            },
+            Offset =
+            {
+                Enable = setting.Offset.Enable,
+                Min = setting.Offset.Min,
+                Max = setting.Offset.Max
             },
             Nps = new()
             {
@@ -485,6 +487,12 @@ public static class LegacyPresetLoader
                 Min = setting.Bombs.Min,
                 Max = setting.Bombs.Max
             },
+            Events =
+            {
+                Enable = setting.Events.Enable,
+                Min = setting.Events.Min,
+                Max = setting.Events.Max
+            },
             Walls = new()
             {
                 Enable = setting.Walls.Enable,
@@ -503,6 +511,36 @@ public static class LegacyPresetLoader
                 Enable = setting.Stars.Enable,
                 Min = setting.Stars.Min,
                 Max = setting.Stars.Max
+            },
+            ParityErrors = new RangeOption<int>
+            {
+                Enable = setting.ParityErrors.Enable,
+                Min = setting.ParityErrors.Min,
+                Max = setting.ParityErrors.Max
+            },
+            ParityWarns = new RangeOption<int>
+            {
+                Enable = setting.ParityWarns.Enable,
+                Min = setting.ParityWarns.Min,
+                Max = setting.ParityWarns.Max
+            },
+            ParityResets = new RangeOption<int>
+            {
+                Enable = setting.ParityResets.Enable,
+                Min = setting.ParityResets.Min,
+                Max = setting.ParityResets.Max
+            },
+            SageScore = new RangeOption<int>
+            {
+                Enable = setting.SageScore.Enable,
+                Min = setting.SageScore.Min,
+                Max = setting.SageScore.Max
+            },
+            MaxScore = new RangeOption<int>
+            {
+                Enable = setting.MaxScore.Enable,
+                Min = setting.MaxScore.Min,
+                Max = setting.MaxScore.Max
             },
             Chinese = new()
             {

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -61,7 +61,8 @@ public static partial class LegacyPresetLoader
     {
         Log.Information("Converting legacy preset to new preset: {Name}", fileName);
         WarnUnsupported(legacyPreset);
-        var options = ConvertFilterOptions(legacyPreset.SongFilter);
+        var songOptions = ConvertSongFilterOptions(legacyPreset.SongFilter);
+        var levelOptions = ConvertLevelFilterOptions(legacyPreset.SongFilter);
         var output = new OutputConfig
         {
             LimitSongs = legacyPreset.Limits.Count.Enable,
@@ -84,6 +85,11 @@ public static partial class LegacyPresetLoader
                 : [legacyPreset.PlaylistInput.Path],
             ManualInput = legacyPreset.ManualSongInput.Songs.ToList()
         };
+        var filterConfig = new FilterConfig
+        {
+            SongDetailFilter = songOptions,
+            LevelDetailOptions = levelOptions
+        };
         Log.Debug("Legacy preset input source: {Source}", legacyPreset.SongSource);
         switch (legacyPreset.SongSource)
         {
@@ -99,15 +105,15 @@ public static partial class LegacyPresetLoader
             case LegacyPreset.DataSource.BeastSaber:
                 throw new LegacyConversionException("BeastSaber source is not supported", "Input Source");
             case LegacyPreset.DataSource.Mapper:
-                MergeMapperSetting(options, legacyPreset.Mapper);
+                MergeMapperSetting(filterConfig, legacyPreset.Mapper);
                 input.Source = SongInputSource.BeatSaver;
                 break;
             case LegacyPreset.DataSource.ScoreSaber:
-                MergeScoreSaberSetting(options, legacyPreset.ScoreSaber);
+                MergeScoreSaberSetting(filterConfig, legacyPreset.ScoreSaber);
                 input.Source = SongInputSource.BeatSaver;
                 break;
             case LegacyPreset.DataSource.BeatSaver:
-                MergeBeatSaverSetting(options, legacyPreset.BeatSaver);
+                MergeBeatSaverSetting(filterConfig, legacyPreset.BeatSaver);
                 input.Source = SongInputSource.BeatSaver;
                 break;
             default:
@@ -126,12 +132,12 @@ public static partial class LegacyPresetLoader
                           $"重制版项目地址：https://github.com/qe201020335/BeatSpiderSharp",
             Input = input,
             Output = output,
-            FilterOptions = [new FilterConfig { DetailFilter = options }]
+            FilterOptions = [filterConfig]
         };
 
 #if DEBUG
-        Log.Debug("Legacy preset: {@LegacyPreset}", legacyPreset);
-        Log.Debug("Converted preset: {@NewPreset}", preset);
+        Log.Verbose("Legacy preset: {@LegacyPreset}", legacyPreset);
+        Log.Verbose("Converted preset: {@NewPreset}", preset);
 #endif
         return preset;
     }
@@ -200,8 +206,10 @@ public static partial class LegacyPresetLoader
         o.Max = max;
     }
 
-    private static void MergeBeatSaverSetting(DetailOptions options, LegacyPreset.BeatSaverSetting setting)
+    private static void MergeBeatSaverSetting(FilterConfig filterConfig, LegacyPreset.BeatSaverSetting setting)
     {
+        var songOptions = filterConfig.SongDetailFilter;
+        var levelOptions = filterConfig.LevelDetailOptions;
         Log.Debug("Merging BeatSaver source settings into filter options");
         if (!string.IsNullOrWhiteSpace(setting.SearchKeyword) || setting.StartPage.HasValue)
         {
@@ -225,7 +233,7 @@ public static partial class LegacyPresetLoader
             { AutoMapper: false } => (true, true) // only auto mapped
         };
 
-        if (options.AutoMapper.Enable && autoMapperEnable && options.AutoMapper.Filter != autoMapperFilter)
+        if (songOptions.AutoMapper.Enable && autoMapperEnable && songOptions.AutoMapper.Filter != autoMapperFilter)
         {
             throw new LegacyConversionException(
                 "Conflicting auto mapper settings from BeatSaver search setting and song filter setting",
@@ -234,8 +242,8 @@ public static partial class LegacyPresetLoader
 
         if (autoMapperEnable)
         {
-            options.AutoMapper.Enable = true;
-            options.AutoMapper.Filter = autoMapperFilter;
+            songOptions.AutoMapper.Enable = true;
+            songOptions.AutoMapper.Filter = autoMapperFilter;
         }
 
         if (setting.RankedSong.Enable)
@@ -243,9 +251,9 @@ public static partial class LegacyPresetLoader
             var states = setting.RankedSong.IsRanked
                 ? new HashSet<RankingStatus> { RankingStatus.Ranked }
                 : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified };
-            if (options.ScoreSaberRanking is { Enable: true, Filter.Count: > 0 })
+            if (songOptions.ScoreSaberRanking is { Enable: true, Filter.Count: > 0 })
             {
-                states.IntersectWith(options.ScoreSaberRanking.Filter);
+                states.IntersectWith(songOptions.ScoreSaberRanking.Filter);
                 if (states.Count == 0)
                 {
                     Log.Error(
@@ -255,41 +263,41 @@ public static partial class LegacyPresetLoader
                 }
             }
 
-            options.ScoreSaberRanking.Enable = true;
-            options.ScoreSaberRanking.Filter.ReplaceWith(states);
+            songOptions.ScoreSaberRanking.Enable = true;
+            songOptions.ScoreSaberRanking.Filter.ReplaceWith(states);
         }
 
-        options.FullSpread.Enable = setting.Difficulty.Enable;
-        options.FullSpread.Filter = setting.Difficulty.IsFullSpread;
+        songOptions.FullSpread.Enable = setting.Difficulty.Enable;
+        songOptions.FullSpread.Filter = setting.Difficulty.IsFullSpread;
 
         if (setting.Bpm.Enable)
         {
             Log.Debug("Merging BeatSaver BPM setting into filter options");
-            CombineRange(options.Bpm, setting.Bpm, "Bpm");
+            CombineRange(songOptions.Bpm, setting.Bpm, "Bpm");
         }
 
         if (setting.Nps.Enable)
         {
             Log.Information("Merging BeatSaver NPS setting into filter options");
-            CombineRange(options.Nps, setting.Nps, "Nps");
+            CombineRange(levelOptions.Nps, setting.Nps, "Nps");
         }
 
         if (setting.Duration.Enable)
         {
             Log.Information("Merging BeatSaver duration setting into filter options");
-            CombineRange(options.Duration, setting.Duration, "Duration");
+            CombineRange(songOptions.Duration, setting.Duration, "Duration");
         }
 
         if (setting.UploadTime.Enable)
         {
             Log.Information("Merging BeatSaver upload time setting into filter options");
-            CombineRange(options.UploadTime, setting.UploadTime, "UploadTime");
+            CombineRange(songOptions.UploadTime, setting.UploadTime, "UploadTime");
         }
 
         if (setting.Rating.Enable)
         {
             Log.Information("Merging BeatSaver rating setting into filter options");
-            CombineRange(options.Rating, setting.Rating, "Rating");
+            CombineRange(songOptions.Rating, setting.Rating, "Rating");
         }
 
         // mods related is a bit tricky
@@ -309,11 +317,11 @@ public static partial class LegacyPresetLoader
         if (setting.RequireMods.Enable && requireMods.Count > 0)
         {
             // BeatSaver tests the values as OR
-            if (options.RequireMods && options.RequireMods.Filter.Count > 0)
+            if (levelOptions.RequireMods && levelOptions.RequireMods.Filter.Count > 0)
             {
                 //Original project only tests this as or
-                Debug.Assert(options.RequireMods.IsOr);
-                if (!options.RequireMods.Filter.SetEquals(requireMods))
+                Debug.Assert(levelOptions.RequireMods.IsOr);
+                if (!levelOptions.RequireMods.Filter.SetEquals(requireMods))
                 {
                     // to achieve this, it needs to AND the results of two OR operations
                     Log.Error(
@@ -325,10 +333,10 @@ public static partial class LegacyPresetLoader
             }
             else
             {
-                options.RequireMods.Enable = true;
-                options.RequireMods.IsOr = true;
-                options.RequireMods.Filter.Clear();
-                options.RequireMods.Filter.UnionWith(requireMods);
+                levelOptions.RequireMods.Enable = true;
+                levelOptions.RequireMods.IsOr = true;
+                levelOptions.RequireMods.Filter.Clear();
+                levelOptions.RequireMods.Filter.UnionWith(requireMods);
             }
         }
 
@@ -344,37 +352,40 @@ public static partial class LegacyPresetLoader
                 throw new LegacyConversionException("Unsupported BeatSaver excluded mods setting", "Excluded Mods");
             }
 
-            if (options.ExcludeMods)
+            if (levelOptions.ExcludeMods)
             {
-                options.ExcludeMods.Filter.Add(excludeMods.First());
+                levelOptions.ExcludeMods.Filter.Add(excludeMods.First());
             }
             else
             {
-                options.ExcludeMods.Enable = true;
-                options.ExcludeMods.Filter.Clear();
-                options.ExcludeMods.Filter.Add(excludeMods.First());
+                levelOptions.ExcludeMods.Enable = true;
+                levelOptions.ExcludeMods.Filter.Clear();
+                levelOptions.ExcludeMods.Filter.Add(excludeMods.First());
             }
         }
     }
 
-    private static void MergeScoreSaberSetting(DetailOptions options, LegacyPreset.ScoreSaberSetting setting)
+    private static void MergeScoreSaberSetting(FilterConfig filterConfig, LegacyPreset.ScoreSaberSetting setting)
     {
+        var songOptions = filterConfig.SongDetailFilter;
+        var levelOptions = filterConfig.LevelDetailOptions;
         Log.Debug("Merging ScoreSaber source setting into filter options");
-        if (options.ScoreSaberRanking && !options.ScoreSaberRanking.SatisfiedBy(RankingStatus.Ranked))
+        if (songOptions.ScoreSaberRanking && !songOptions.ScoreSaberRanking.SatisfiedBy(RankingStatus.Ranked))
         {
             Log.Error("Conflicting ScoreSaber ranking status. Existing filter setting does not include {Status}",
                 RankingStatus.Ranked);
             throw new LegacyConversionException("Conflicting ScoreSaber ranking status", "ScoreSaberRanking");
         }
 
-        options.ScoreSaberRanking.Enable = true;
-        options.ScoreSaberRanking.Filter.Clear();
-        options.ScoreSaberRanking.Filter.Add(RankingStatus.Ranked);
-        CombineRange(options.ScoreSaberStars, setting.StarDifficulty, "ScoreSaber stars");
+        songOptions.ScoreSaberRanking.Enable = true;
+        songOptions.ScoreSaberRanking.Filter.Clear();
+        songOptions.ScoreSaberRanking.Filter.Add(RankingStatus.Ranked);
+        CombineRange(levelOptions.ScoreSaberStars, setting.StarDifficulty, "ScoreSaber stars");
     }
 
-    private static void MergeMapperSetting(DetailOptions options, LegacyPreset.MapperSetting setting)
+    private static void MergeMapperSetting(FilterConfig filterConfig, LegacyPreset.MapperSetting setting)
     {
+        var options = filterConfig.SongDetailFilter;
         var url = setting.MapperAddress;
         Log.Debug("Extracting uploader id from mapper url: {Url}", url);
         var match = MapperUrlRegex().Match(url);
@@ -400,221 +411,223 @@ public static partial class LegacyPresetLoader
         }
     }
 
-    private static DetailOptions ConvertFilterOptions(LegacyPreset.SongFilterSetting setting)
+    private static SongDetailOptions ConvertSongFilterOptions(LegacyPreset.SongFilterSetting setting) => new()
     {
-        return new DetailOptions
+        UploaderId = new IncludeOption<int>
         {
-            UploaderId = new()
-            {
-                Enable = setting.UploaderIds.Enable,
-                Filter = setting.UploaderIds.Content.ToHashSet()
-            },
-            UploaderName = new()
-            {
-                Enable = setting.UploaderNames.Enable,
-                Filter = setting.UploaderNames.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase)
-            },
-            RequireMods = new LogicIncludeOption<MMod>
-            {
-                Enable = setting.RequireMods.Enable,
-                Filter = setting.RequireMods.Mods.ToMMods(),
-                IsOr = true
-            },
-            ExcludeMods = new ExcludeOption<MMod>
-            {
-                Enable = setting.ExcludeMods.Enable,
-                Filter = setting.ExcludeMods.Mods.ToMMods()
-            },
-            IncludeCharacteristics = new LogicIncludeOption<MCharacteristic>
-            {
-                Enable = setting.IncludeCharacteristics.Enable,
-                Filter = setting.IncludeCharacteristics.Characteristics.Select(EnumConversions.ToMCharacteristic)
-                    .ToHashSet(),
-                IsOr = true
-            },
-            IncludeDifficulties = new LogicIncludeOption<MDifficulty>
-            {
-                Enable = setting.IncludeDifficulties.Enable,
-                Filter = setting.IncludeDifficulties.Difficulties.Select(EnumConversions.ToMDifficulty).ToHashSet(),
-                IsOr = !setting.IncludeDifficulties.And
-            },
-            Downloads = new RangeOption<int>
-            {
-                Enable = setting.DownloadCount.Enable,
-                Min = setting.DownloadCount.Min,
-                Max = setting.DownloadCount.Max
-            },
-            Plays = new RangeOption<int>
-            {
-                Enable = setting.PlayCount.Enable,
-                Min = setting.PlayCount.Min,
-                Max = setting.PlayCount.Max
-            },
-            UpVotes = new()
-            {
-                Enable = setting.UpVotes.Enable,
-                Min = setting.UpVotes.Min,
-                Max = setting.UpVotes.Max
-            },
-            UpVotePercentage = new()
-            {
-                Enable = setting.UpVotePercentage.Enable,
-                Min = setting.UpVotePercentage.Min,
-                Max = setting.UpVotePercentage.Max
-            },
-            DownVotes = new()
-            {
-                Enable = setting.DownVotes.Enable,
-                Min = setting.DownVotes.Min,
-                Max = setting.DownVotes.Max
-            },
-            DownVotePercentage = new()
-            {
-                Enable = setting.DownVotePercentage.Enable,
-                Min = setting.DownVotePercentage.Min,
-                Max = setting.DownVotePercentage.Max
-            },
-            Rating = new()
-            {
-                Enable = setting.Rating.Enable,
-                Min = setting.Rating.Min,
-                Max = setting.Rating.Max
-            },
-            AutoMapper = new(setting.AutoMapper.AutoMapper)
-            {
-                Enable = setting.AutoMapper.Enable
-            },
-            ScoreSaberRanking = new IncludeOption<RankingStatus>
-            {
-                Enable = setting.RankedSong.Enable,
-                Filter = setting.RankedSong.IsRanked
-                    ? new HashSet<RankingStatus> { RankingStatus.Ranked }
-                    : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified }
-            },
-            Chinese = new Option
-            {
-                Enable = setting.FilterChinese.Enable
-            },
-            Bpm = new()
-            {
-                Enable = setting.Bpm.Enable,
-                Min = setting.Bpm.Min,
-                Max = setting.Bpm.Max
-            },
-            Duration = new()
-            {
-                Enable = setting.Duration.Enable,
-                Min = setting.Duration.Min,
-                Max = setting.Duration.Max
-            },
-            Seconds = new()
-            {
-                Enable = setting.MapSeconds.Enable,
-                Min = setting.MapSeconds.Min,
-                Max = setting.MapSeconds.Max
-            },
-            Beats = new()
-            {
-                Enable = setting.MapLength.Enable,
-                Min = setting.MapLength.Min,
-                Max = setting.MapLength.Max
-            },
-            Njs = new()
-            {
-                Enable = setting.Njs.Enable,
-                Min = setting.Njs.Min,
-                Max = setting.Njs.Max
-            },
-            Offset = new()
-            {
-                Enable = setting.Offset.Enable,
-                Min = setting.Offset.Min,
-                Max = setting.Offset.Max
-            },
-            Notes = new RangeOption<int>
-            {
-                Enable = setting.Notes.Enable,
-                Min = setting.Notes.Min,
-                Max = setting.Notes.Max
-            },
-            Nps = new()
-            {
-                Enable = setting.Nps.Enable,
-                Min = setting.Nps.Min,
-                Max = setting.Nps.Max
-            },
-            Bombs = new()
-            {
-                Enable = setting.Bombs.Enable,
-                Min = setting.Bombs.Min,
-                Max = setting.Bombs.Max
-            },
-            Events = new()
-            {
-                Enable = setting.Events.Enable,
-                Min = setting.Events.Min,
-                Max = setting.Events.Max
-            },
-            Walls = new()
-            {
-                Enable = setting.Walls.Enable,
-                Min = setting.Walls.Min,
-                Max = setting.Walls.Max
-            },
-            ScoreSaberStars = new()
-            {
-                Enable = setting.Stars.Enable,
-                Min = setting.Stars.Min,
-                Max = setting.Stars.Max
-            },
-            ParityErrors = new RangeOption<int>
-            {
-                Enable = setting.ParityErrors.Enable,
-                Min = setting.ParityErrors.Min,
-                Max = setting.ParityErrors.Max
-            },
-            ParityWarns = new RangeOption<int>
-            {
-                Enable = setting.ParityWarns.Enable,
-                Min = setting.ParityWarns.Min,
-                Max = setting.ParityWarns.Max
-            },
-            ParityResets = new RangeOption<int>
-            {
-                Enable = setting.ParityResets.Enable,
-                Min = setting.ParityResets.Min,
-                Max = setting.ParityResets.Max
-            },
-            UploadTime = new RangeOption<DateTimeOffset>
-            {
-                Enable = setting.UploadTime.Enable,
-                Min = setting.UploadTime.Min,
-                Max = setting.UploadTime.Max
-            },
-            IncludeTags = new LogicIncludeOption<string>
-            {
-                Enable = setting.Tags.Include.Enable,
-                Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
-                IsOr = !setting.Tags.Include.And
-            },
-            ExcludeTags = new LogicExcludeOption<string>
-            {
-                Enable = setting.Tags.Exclude.Enable,
-                Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
-                IsOr = !setting.Tags.Exclude.And
-            },
-            SageScore = new RangeOption<int>
-            {
-                Enable = setting.SageScore.Enable,
-                Min = setting.SageScore.Min,
-                Max = setting.SageScore.Max
-            },
-            MaxScore = new RangeOption<int>
-            {
-                Enable = setting.MaxScore.Enable,
-                Min = setting.MaxScore.Min,
-                Max = setting.MaxScore.Max
-            }
-        };
-    }
+            Enable = setting.UploaderIds.Enable,
+            Filter = setting.UploaderIds.Content.ToHashSet()
+        },
+        UploaderName = new IncludeOption<string>
+        {
+            Enable = setting.UploaderNames.Enable,
+            Filter = setting.UploaderNames.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase)
+        },
+        Downloads = new RangeOption<int>
+        {
+            Enable = setting.DownloadCount.Enable,
+            Min = setting.DownloadCount.Min,
+            Max = setting.DownloadCount.Max
+        },
+        Plays = new RangeOption<int>
+        {
+            Enable = setting.PlayCount.Enable,
+            Min = setting.PlayCount.Min,
+            Max = setting.PlayCount.Max
+        },
+        UpVotes = new RangeOption<int>
+        {
+            Enable = setting.UpVotes.Enable,
+            Min = setting.UpVotes.Min,
+            Max = setting.UpVotes.Max
+        },
+        UpVotePercentage = new RangeOption<float>
+        {
+            Enable = setting.UpVotePercentage.Enable,
+            Min = setting.UpVotePercentage.Min,
+            Max = setting.UpVotePercentage.Max
+        },
+        DownVotes = new RangeOption<int>
+        {
+            Enable = setting.DownVotes.Enable,
+            Min = setting.DownVotes.Min,
+            Max = setting.DownVotes.Max
+        },
+        DownVotePercentage = new RangeOption<float>
+        {
+            Enable = setting.DownVotePercentage.Enable,
+            Min = setting.DownVotePercentage.Min,
+            Max = setting.DownVotePercentage.Max
+        },
+        Rating = new RangeOption<float>
+        {
+            Enable = setting.Rating.Enable,
+            Min = setting.Rating.Min,
+            Max = setting.Rating.Max
+        },
+        AutoMapper = new Option<bool>(setting.AutoMapper.AutoMapper)
+        {
+            Enable = setting.AutoMapper.Enable
+        },
+        ScoreSaberRanking = new IncludeOption<RankingStatus>
+        {
+            Enable = setting.RankedSong.Enable,
+            Filter = setting.RankedSong.IsRanked
+                ? new HashSet<RankingStatus> { RankingStatus.Ranked }
+                : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified }
+        },
+        Chinese = new Option
+        {
+            Enable = setting.FilterChinese.Enable
+        },
+        Bpm = new RangeOption<float>
+        {
+            Enable = setting.Bpm.Enable,
+            Min = setting.Bpm.Min,
+            Max = setting.Bpm.Max
+        },
+        Duration = new RangeOption<int>
+        {
+            Enable = setting.Duration.Enable,
+            Min = setting.Duration.Min,
+            Max = setting.Duration.Max
+        },
+
+        UploadTime = new RangeOption<DateTimeOffset>
+        {
+            Enable = setting.UploadTime.Enable,
+            Min = setting.UploadTime.Min,
+            Max = setting.UploadTime.Max
+        },
+        IncludeTags = new LogicIncludeOption<string>
+        {
+            Enable = setting.Tags.Include.Enable,
+            Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
+            IsOr = !setting.Tags.Include.And
+        },
+        ExcludeTags = new LogicExcludeOption<string>
+        {
+            Enable = setting.Tags.Exclude.Enable,
+            Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
+            IsOr = !setting.Tags.Exclude.And
+        },
+        SageScore = new RangeOption<int>
+        {
+            Enable = setting.SageScore.Enable,
+            Min = setting.SageScore.Min,
+            Max = setting.SageScore.Max
+        }
+    };
+
+    private static LevelDetailOptions ConvertLevelFilterOptions(LegacyPreset.SongFilterSetting setting) => new()
+    {
+        RequireMods = new LogicIncludeOption<MMod>
+        {
+            Enable = setting.RequireMods.Enable,
+            Filter = setting.RequireMods.Mods.ToMMods(),
+            IsOr = true
+        },
+        ExcludeMods = new ExcludeOption<MMod>
+        {
+            Enable = setting.ExcludeMods.Enable,
+            Filter = setting.ExcludeMods.Mods.ToMMods()
+        },
+        IncludeCharacteristics = new LogicIncludeOption<MCharacteristic>
+        {
+            Enable = setting.IncludeCharacteristics.Enable,
+            Filter = setting.IncludeCharacteristics.Characteristics.Select(EnumConversions.ToMCharacteristic)
+                .ToHashSet(),
+            IsOr = true
+        },
+        IncludeDifficulties = new LogicIncludeOption<MDifficulty>
+        {
+            Enable = setting.IncludeDifficulties.Enable,
+            Filter = setting.IncludeDifficulties.Difficulties.Select(EnumConversions.ToMDifficulty).ToHashSet(),
+            IsOr = !setting.IncludeDifficulties.And
+        },
+        Seconds = new RangeOption<float>
+        {
+            Enable = setting.MapSeconds.Enable,
+            Min = setting.MapSeconds.Min,
+            Max = setting.MapSeconds.Max
+        },
+        Beats = new RangeOption<float>
+        {
+            Enable = setting.MapLength.Enable,
+            Min = setting.MapLength.Min,
+            Max = setting.MapLength.Max
+        },
+        Njs = new RangeOption<float>
+        {
+            Enable = setting.Njs.Enable,
+            Min = setting.Njs.Min,
+            Max = setting.Njs.Max
+        },
+        Offset = new RangeOption<float>
+        {
+            Enable = setting.Offset.Enable,
+            Min = setting.Offset.Min,
+            Max = setting.Offset.Max
+        },
+        Notes = new RangeOption<int>
+        {
+            Enable = setting.Notes.Enable,
+            Min = setting.Notes.Min,
+            Max = setting.Notes.Max
+        },
+        Nps = new RangeOption<float>
+        {
+            Enable = setting.Nps.Enable,
+            Min = setting.Nps.Min,
+            Max = setting.Nps.Max
+        },
+        Bombs = new RangeOption<int>
+        {
+            Enable = setting.Bombs.Enable,
+            Min = setting.Bombs.Min,
+            Max = setting.Bombs.Max
+        },
+        Events = new RangeOption<int>
+        {
+            Enable = setting.Events.Enable,
+            Min = setting.Events.Min,
+            Max = setting.Events.Max
+        },
+        Walls = new RangeOption<int>
+        {
+            Enable = setting.Walls.Enable,
+            Min = setting.Walls.Min,
+            Max = setting.Walls.Max
+        },
+        ScoreSaberStars = new RangeOption<float>
+        {
+            Enable = setting.Stars.Enable,
+            Min = setting.Stars.Min,
+            Max = setting.Stars.Max
+        },
+        ParityErrors = new RangeOption<int>
+        {
+            Enable = setting.ParityErrors.Enable,
+            Min = setting.ParityErrors.Min,
+            Max = setting.ParityErrors.Max
+        },
+        ParityWarns = new RangeOption<int>
+        {
+            Enable = setting.ParityWarns.Enable,
+            Min = setting.ParityWarns.Min,
+            Max = setting.ParityWarns.Max
+        },
+        ParityResets = new RangeOption<int>
+        {
+            Enable = setting.ParityResets.Enable,
+            Min = setting.ParityResets.Min,
+            Max = setting.ParityResets.Max
+        },
+        MaxScore = new RangeOption<int>
+        {
+            Enable = setting.MaxScore.Enable,
+            Min = setting.MaxScore.Min,
+            Max = setting.MaxScore.Max
+        }
+    };
 }

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -9,10 +9,11 @@ using Serilog;
 
 namespace BeatSpiderSharp.Legacy;
 
-public static class LegacyPresetLoader
+public static partial class LegacyPresetLoader
 {
     //beatsaver.com/profile/58338
-    private static readonly Regex MapperUrlRegex = new(@"beatsaver.com/profile/(\d+)", RegexOptions.Compiled);
+    [GeneratedRegex(@"beatsaver\.com/profile/(\d+)")]
+    private static partial Regex MapperUrlRegex();
 
     private static readonly JsonSerializer LegacySerializer = JsonSerializer.Create(new JsonSerializerSettings
     {
@@ -376,7 +377,7 @@ public static class LegacyPresetLoader
     {
         var url = setting.MapperAddress;
         Log.Debug("Extracting uploader id from mapper url: {Url}", url);
-        var match = MapperUrlRegex.Match(url);
+        var match = MapperUrlRegex().Match(url);
         if (match is { Success: true, Groups.Count: 2 } && int.TryParse(match.Groups[1].Value, out var id))
         {
             Log.Information("Found uploader id from mapper url: {Url}", url);

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -31,8 +31,16 @@ public static class LegacyPresetLoader
 #if DEBUG
         SaveLegacyPreset(legacy, $"./{Path.GetFileName(path)}.legacy.saved.json");
 #endif
-        var preset = ConvertToPreset(legacy, Path.GetFileNameWithoutExtension(path), author);
-        return preset;
+        try
+        {
+            var preset = ConvertToPreset(legacy, Path.GetFileNameWithoutExtension(path), author);
+            return preset;
+        }
+        catch (Exception e) when (e is not LegacyConversionException)
+        {
+            Log.Error(e, "Unexpected exception when converting legacy preset");
+            throw new LegacyConversionException("Failed to convert legacy preset", innerException: e);
+        }
     }
 
     internal static LegacyPreset? LoadLegacyPreset(string path)
@@ -87,9 +95,7 @@ public static class LegacyPresetLoader
                 input.Source = SongInputSource.ManualInput;
                 break;
             case LegacyPreset.DataSource.BeastSaber:
-                Log.Warning("BeastSaber source is not supported!");
-                input.Source = SongInputSource.BeatSaver;
-                break;
+                throw new LegacyConversionException("BeastSaber source is not supported", "Input Source");
             case LegacyPreset.DataSource.Mapper:
                 MergeMapperSetting(options, legacyPreset.Mapper);
                 input.Source = SongInputSource.BeatSaver;
@@ -103,9 +109,8 @@ public static class LegacyPresetLoader
                 input.Source = SongInputSource.BeatSaver;
                 break;
             default:
-                Log.Warning("Unknown song source from legacy preset: {Source}", legacyPreset.SongSource);
-                input.Source = SongInputSource.BeatSaver;
-                break;
+                throw new LegacyConversionException(
+                    $"Unknown song source from legacy preset: {legacyPreset.SongSource}", "Input Source");
         }
 
         var name = GetPresetName(fileName);
@@ -216,21 +221,30 @@ public static class LegacyPresetLoader
         }
     }
 
-    private static void CombineRange<T>(RangeOption<T> o, LegacyPreset.IMinMaxSetting<T> s) where T : struct, IComparable<T>
+    //TODO Unit tests
+    private static void CombineRange<T>(RangeOption<T> o, LegacyPreset.IMinMaxSetting<T> s, string name)
+        where T : struct, IComparable<T>
     {
-        var min1 = o.Min;
-        var max1 = o.Max;
-        var min2 = s.Min;
-        var max2 = s.Max;
+        var min = s.Min;
+        var max = s.Max;
         if (o.Enable)
         {
-            min1 = min1.HasValue && min2.HasValue ? min1.Value.CompareTo(min2.Value) > 0 ? min1 : min2 : min1 ?? min2;
-            max1 = max1.HasValue && max2.HasValue ? max1.Value.CompareTo(max2.Value) < 0 ? max1 : max2 : max1 ?? max2;
+            var oMin = o.Min;
+            var oMax = o.Max;
+            //merge the range values
+            min = oMin.HasValue && min.HasValue ? oMin.Value.CompareTo(min.Value) > 0 ? oMin : min : oMin ?? min;
+            max = oMax.HasValue && max.HasValue ? oMax.Value.CompareTo(max.Value) < 0 ? oMax : max : oMax ?? max;
+        }
+
+        if (min.HasValue && max.HasValue && min.Value.CompareTo(max.Value) > 0)
+        {
+            Log.Error("Invalid range with min greater than max. Min: {Min}, Max: {Max}", min.Value, max.Value);
+            throw new LegacyConversionException("Invalid range with min greater than max.", name);
         }
 
         o.Enable = true;
-        o.Min = min1;
-        o.Max = max1;
+        o.Min = min;
+        o.Max = max;
     }
 
     private static void MergeBeatSaverSetting(DetailOptions options, LegacyPreset.BeatSaverSetting setting)
@@ -238,7 +252,16 @@ public static class LegacyPresetLoader
         Log.Debug("Merging BeatSaver source settings into filter options");
         if (!string.IsNullOrWhiteSpace(setting.SearchKeyword) || setting.StartPage.HasValue)
         {
-            Log.Warning("BeatSaver search and page number are not supported!");
+            //TODO add search keyword to search filter settings once search filter is supported
+            throw new LegacyConversionException("BeatSaver search keyword and starting page are not supported",
+                "BeatSaver Search");
+        }
+
+        if (setting.Sort != LegacyPreset.BeatSaverSetting.SortType.Latest)
+        {
+            throw new LegacyConversionException(
+                $"Only {nameof(LegacyPreset.BeatSaverSetting.SortType.Latest)} BeatSaver search sort type is supported",
+                "BeatSaver Search");
         }
 
         if (setting.AutoMapper.Enable)
@@ -263,31 +286,31 @@ public static class LegacyPresetLoader
         if (setting.Bpm.Enable)
         {
             Log.Debug("Merging BeatSaver BPM setting into filter options");
-            CombineRange(options.Bpm, setting.Bpm);
+            CombineRange(options.Bpm, setting.Bpm, "Bpm");
         }
 
         if (setting.Nps.Enable)
         {
-            Log.Debug("Merging BeatSaver NPS setting into filter options");
-            CombineRange(options.Nps, setting.Nps);
+            Log.Information("Merging BeatSaver NPS setting into filter options");
+            CombineRange(options.Nps, setting.Nps, "Nps");
         }
 
         if (setting.Duration.Enable)
         {
-            Log.Debug("Merging BeatSaver duration setting into filter options");
-            CombineRange(options.Duration, setting.Duration);
+            Log.Information("Merging BeatSaver duration setting into filter options");
+            CombineRange(options.Duration, setting.Duration, "Duration");
         }
 
         if (setting.UploadTime.Enable)
         {
-            Log.Debug("Merging BeatSaver upload time setting into filter options");
-            CombineRange(options.UploadTime, setting.UploadTime);
+            Log.Information("Merging BeatSaver upload time setting into filter options");
+            CombineRange(options.UploadTime, setting.UploadTime, "UploadTime");
         }
 
         if (setting.Rating.Enable)
         {
-            Log.Debug("Merging BeatSaver rating setting into filter options");
-            CombineRange(options.Rating, setting.Rating);
+            Log.Information("Merging BeatSaver rating setting into filter options");
+            CombineRange(options.Rating, setting.Rating, "Rating");
         }
 
         if (setting.RequireMods.Enable)
@@ -310,7 +333,7 @@ public static class LegacyPresetLoader
         Log.Debug("Merging ScoreSaber source setting into filter options");
         options.ScoreSaberRanking.Enable = true;
         options.ScoreSaberRanking.Filter = new HashSet<RankingStatus> { RankingStatus.Ranked };
-        CombineRange(options.ScoreSaberStars, setting.StarDifficulty);
+        CombineRange(options.ScoreSaberStars, setting.StarDifficulty, "ScoreSaber stars");
     }
 
     private static void MergeMapperSetting(DetailOptions options, LegacyPreset.MapperSetting setting)
@@ -323,7 +346,10 @@ public static class LegacyPresetLoader
             Log.Information("Found uploader id from mapper url: {Url}", url);
             if (options.UploaderId.Enable && !options.UploaderId.Filter.Contains(id))
             {
-                Log.Warning("Overwriting existing UploaderID filter to {New}", id);
+                Log.Error("Conflicting uploader id. '{Id1}' from url is not included in filter setting {Id2}", id,
+                    options.UploaderId.Filter);
+                throw new LegacyConversionException("Conflicting uploader id from url and song filter setting",
+                    "Mapper Url");
             }
 
             options.UploaderId.Enable = true;
@@ -332,7 +358,8 @@ public static class LegacyPresetLoader
         }
         else
         {
-            Log.Warning("Failed to find uploader id from mapper url: {Url}", url);
+            Log.Error("Failed to find uploader id from mapper url: {Url}", url);
+            throw new LegacyConversionException("Cannot find uploader id from mapper url", "Mapper Url");
         }
     }
 

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -256,7 +256,7 @@ public static partial class LegacyPresetLoader
             }
 
             options.ScoreSaberRanking.Enable = true;
-            options.ScoreSaberRanking.Filter = states;
+            options.ScoreSaberRanking.Filter.ReplaceWith(states);
         }
 
         options.FullSpread.Enable = setting.Difficulty.Enable;
@@ -404,12 +404,12 @@ public static partial class LegacyPresetLoader
     {
         return new DetailOptions
         {
-            UploaderId =
+            UploaderId = new()
             {
                 Enable = setting.UploaderIds.Enable,
                 Filter = setting.UploaderIds.Content.ToHashSet()
             },
-            UploaderName =
+            UploaderName = new()
             {
                 Enable = setting.UploaderNames.Enable,
                 Filter = setting.UploaderNames.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase)
@@ -426,7 +426,7 @@ public static partial class LegacyPresetLoader
                 Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
                 IsOr = !setting.Tags.Include.And
             },
-            ExcludeTags =
+            ExcludeTags = new()
             {
                 Enable = setting.Tags.Exclude.Enable,
                 Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
@@ -481,27 +481,26 @@ public static partial class LegacyPresetLoader
                 Filter = setting.RequireMods.Mods.ToMMods(),
                 IsOr = true
             },
-            ExcludeMods =
+            ExcludeMods = new()
             {
                 Enable = setting.ExcludeMods.Enable,
                 Filter = setting.ExcludeMods.Mods.ToMMods()
             },
-            Downloads =
+            Downloads = new()
             {
                 Enable = setting.DownloadCount.Enable,
                 Min = setting.DownloadCount.Min,
                 Max = setting.DownloadCount.Max
             },
-            Plays =
+            Plays = new()
             {
                 Enable = setting.PlayCount.Enable,
                 Min = setting.PlayCount.Min,
                 Max = setting.PlayCount.Max
             },
-            AutoMapper =
+            AutoMapper = new(setting.AutoMapper.AutoMapper)
             {
-                Enable = setting.AutoMapper.Enable,
-                Filter = setting.AutoMapper.AutoMapper
+                Enable = setting.AutoMapper.Enable
             },
             Bpm = new()
             {
@@ -515,13 +514,13 @@ public static partial class LegacyPresetLoader
                 Min = setting.Duration.Min,
                 Max = setting.Duration.Max
             },
-            Seconds =
+            Seconds = new()
             {
                 Enable = setting.MapSeconds.Enable,
                 Min = setting.MapSeconds.Min,
                 Max = setting.MapSeconds.Max
             },
-            Beats =
+            Beats = new()
             {
                 Enable = setting.MapLength.Enable,
                 Min = setting.MapLength.Min,
@@ -533,7 +532,7 @@ public static partial class LegacyPresetLoader
                 Min = setting.Njs.Min,
                 Max = setting.Njs.Max
             },
-            Offset =
+            Offset = new()
             {
                 Enable = setting.Offset.Enable,
                 Min = setting.Offset.Min,
@@ -557,7 +556,7 @@ public static partial class LegacyPresetLoader
                 Min = setting.Bombs.Min,
                 Max = setting.Bombs.Max
             },
-            Events =
+            Events = new()
             {
                 Enable = setting.Events.Enable,
                 Min = setting.Events.Min,
@@ -569,7 +568,7 @@ public static partial class LegacyPresetLoader
                 Min = setting.Walls.Min,
                 Max = setting.Walls.Max
             },
-            ScoreSaberRanking =
+            ScoreSaberRanking = new()
             {
                 Enable = setting.RankedSong.Enable,
                 Filter = setting.RankedSong.IsRanked

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -101,7 +101,7 @@ public static class LegacyPresetLoader
                 input.Source = SongInputSource.BeatSaver;
                 break;
             case LegacyPreset.DataSource.ScoreSaber:
-                MergeScoreSaverSetting(options, legacyPreset.ScoreSaber);
+                MergeScoreSaberSetting(options, legacyPreset.ScoreSaber);
                 input.Source = SongInputSource.BeatSaver;
                 break;
             case LegacyPreset.DataSource.BeatSaver:
@@ -295,11 +295,19 @@ public static class LegacyPresetLoader
         }
     }
 
-    private static void MergeScoreSaverSetting(DetailOptions options, LegacyPreset.ScoreSaberSetting setting)
+    private static void MergeScoreSaberSetting(DetailOptions options, LegacyPreset.ScoreSaberSetting setting)
     {
         Log.Debug("Merging ScoreSaber source setting into filter options");
+        if (options.ScoreSaberRanking && !options.ScoreSaberRanking.SatisfiedBy(RankingStatus.Ranked))
+        {
+            Log.Error("Conflicting ScoreSaber ranking status. Existing filter setting does not include {Status}",
+                RankingStatus.Ranked);
+            throw new LegacyConversionException("Conflicting ScoreSaber ranking status", "ScoreSaberRanking");
+        }
+
         options.ScoreSaberRanking.Enable = true;
-        options.ScoreSaberRanking.Filter = new HashSet<RankingStatus> { RankingStatus.Ranked };
+        options.ScoreSaberRanking.Filter.Clear();
+        options.ScoreSaberRanking.Filter.Add(RankingStatus.Ranked);
         CombineRange(options.ScoreSaberStars, setting.StarDifficulty, "ScoreSaber stars");
     }
 
@@ -311,7 +319,7 @@ public static class LegacyPresetLoader
         if (match is { Success: true, Groups.Count: 2 } && int.TryParse(match.Groups[1].Value, out var id))
         {
             Log.Information("Found uploader id from mapper url: {Url}", url);
-            if (options.UploaderId.Enable && !options.UploaderId.Filter.Contains(id))
+            if (options.UploaderId && !options.UploaderId.SatisfiedBy(id))
             {
                 Log.Error("Conflicting uploader id. '{Id1}' from url is not included in filter setting {Id2}", id,
                     options.UploaderId.Filter);

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -414,23 +414,41 @@ public static partial class LegacyPresetLoader
                 Enable = setting.UploaderNames.Enable,
                 Filter = setting.UploaderNames.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase)
             },
-            UploadTime = new()
+            RequireMods = new LogicIncludeOption<MMod>
             {
-                Enable = setting.UploadTime.Enable,
-                Min = setting.UploadTime.Min,
-                Max = setting.UploadTime.Max
+                Enable = setting.RequireMods.Enable,
+                Filter = setting.RequireMods.Mods.ToMMods(),
+                IsOr = true
             },
-            IncludeTags = new()
+            ExcludeMods = new ExcludeOption<MMod>
             {
-                Enable = setting.Tags.Include.Enable,
-                Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
-                IsOr = !setting.Tags.Include.And
+                Enable = setting.ExcludeMods.Enable,
+                Filter = setting.ExcludeMods.Mods.ToMMods()
             },
-            ExcludeTags = new()
+            IncludeCharacteristics = new LogicIncludeOption<MCharacteristic>
             {
-                Enable = setting.Tags.Exclude.Enable,
-                Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
-                IsOr = !setting.Tags.Exclude.And
+                Enable = setting.IncludeCharacteristics.Enable,
+                Filter = setting.IncludeCharacteristics.Characteristics.Select(EnumConversions.ToMCharacteristic)
+                    .ToHashSet(),
+                IsOr = true
+            },
+            IncludeDifficulties = new LogicIncludeOption<MDifficulty>
+            {
+                Enable = setting.IncludeDifficulties.Enable,
+                Filter = setting.IncludeDifficulties.Difficulties.Select(EnumConversions.ToMDifficulty).ToHashSet(),
+                IsOr = !setting.IncludeDifficulties.And
+            },
+            Downloads = new RangeOption<int>
+            {
+                Enable = setting.DownloadCount.Enable,
+                Min = setting.DownloadCount.Min,
+                Max = setting.DownloadCount.Max
+            },
+            Plays = new RangeOption<int>
+            {
+                Enable = setting.PlayCount.Enable,
+                Min = setting.PlayCount.Min,
+                Max = setting.PlayCount.Max
             },
             UpVotes = new()
             {
@@ -462,45 +480,20 @@ public static partial class LegacyPresetLoader
                 Min = setting.Rating.Min,
                 Max = setting.Rating.Max
             },
-            IncludeCharacteristics = new()
-            {
-                Enable = setting.IncludeCharacteristics.Enable,
-                Filter = setting.IncludeCharacteristics.Characteristics.Select(EnumConversions.ToMCharacteristic)
-                    .ToHashSet(),
-                IsOr = true
-            },
-            IncludeDifficulties = new()
-            {
-                Enable = setting.IncludeDifficulties.Enable,
-                Filter = setting.IncludeDifficulties.Difficulties.Select(EnumConversions.ToMDifficulty).ToHashSet(),
-                IsOr = !setting.IncludeDifficulties.And
-            },
-            RequireMods = new()
-            {
-                Enable = setting.RequireMods.Enable,
-                Filter = setting.RequireMods.Mods.ToMMods(),
-                IsOr = true
-            },
-            ExcludeMods = new()
-            {
-                Enable = setting.ExcludeMods.Enable,
-                Filter = setting.ExcludeMods.Mods.ToMMods()
-            },
-            Downloads = new()
-            {
-                Enable = setting.DownloadCount.Enable,
-                Min = setting.DownloadCount.Min,
-                Max = setting.DownloadCount.Max
-            },
-            Plays = new()
-            {
-                Enable = setting.PlayCount.Enable,
-                Min = setting.PlayCount.Min,
-                Max = setting.PlayCount.Max
-            },
             AutoMapper = new(setting.AutoMapper.AutoMapper)
             {
                 Enable = setting.AutoMapper.Enable
+            },
+            ScoreSaberRanking = new IncludeOption<RankingStatus>
+            {
+                Enable = setting.RankedSong.Enable,
+                Filter = setting.RankedSong.IsRanked
+                    ? new HashSet<RankingStatus> { RankingStatus.Ranked }
+                    : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified }
+            },
+            Chinese = new Option
+            {
+                Enable = setting.FilterChinese.Enable
             },
             Bpm = new()
             {
@@ -538,17 +531,17 @@ public static partial class LegacyPresetLoader
                 Min = setting.Offset.Min,
                 Max = setting.Offset.Max
             },
+            Notes = new RangeOption<int>
+            {
+                Enable = setting.Notes.Enable,
+                Min = setting.Notes.Min,
+                Max = setting.Notes.Max
+            },
             Nps = new()
             {
                 Enable = setting.Nps.Enable,
                 Min = setting.Nps.Min,
                 Max = setting.Nps.Max
-            },
-            Notes = new()
-            {
-                Enable = setting.Notes.Enable,
-                Min = setting.Notes.Min,
-                Max = setting.Notes.Max
             },
             Bombs = new()
             {
@@ -567,13 +560,6 @@ public static partial class LegacyPresetLoader
                 Enable = setting.Walls.Enable,
                 Min = setting.Walls.Min,
                 Max = setting.Walls.Max
-            },
-            ScoreSaberRanking = new()
-            {
-                Enable = setting.RankedSong.Enable,
-                Filter = setting.RankedSong.IsRanked
-                    ? new HashSet<RankingStatus> { RankingStatus.Ranked }
-                    : new HashSet<RankingStatus> { RankingStatus.Unranked, RankingStatus.Qualified }
             },
             ScoreSaberStars = new()
             {
@@ -599,6 +585,24 @@ public static partial class LegacyPresetLoader
                 Min = setting.ParityResets.Min,
                 Max = setting.ParityResets.Max
             },
+            UploadTime = new RangeOption<DateTimeOffset>
+            {
+                Enable = setting.UploadTime.Enable,
+                Min = setting.UploadTime.Min,
+                Max = setting.UploadTime.Max
+            },
+            IncludeTags = new LogicIncludeOption<string>
+            {
+                Enable = setting.Tags.Include.Enable,
+                Filter = setting.Tags.Include.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
+                IsOr = !setting.Tags.Include.And
+            },
+            ExcludeTags = new LogicExcludeOption<string>
+            {
+                Enable = setting.Tags.Exclude.Enable,
+                Filter = setting.Tags.Exclude.Content.ToHashSet(StringComparer.InvariantCultureIgnoreCase),
+                IsOr = !setting.Tags.Exclude.And
+            },
             SageScore = new RangeOption<int>
             {
                 Enable = setting.SageScore.Enable,
@@ -610,10 +614,6 @@ public static partial class LegacyPresetLoader
                 Enable = setting.MaxScore.Enable,
                 Min = setting.MaxScore.Min,
                 Max = setting.MaxScore.Max
-            },
-            Chinese = new()
-            {
-                Enable = setting.FilterChinese.Enable
             }
         };
     }

--- a/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
+++ b/Libs/BeatSpiderSharp.Legacy/LegacyPresetLoader.cs
@@ -257,10 +257,8 @@ public static class LegacyPresetLoader
             options.ScoreSaberRanking.Filter = new HashSet<RankingStatus> { RankingStatus.Ranked };
         }
 
-        if (setting.Difficulty.Enable)
-        {
-            options.FullSpread.Enable = options.FullSpread.Enable || setting.Difficulty.IsFullSpread;
-        }
+        options.FullSpread.Enable = setting.Difficulty.Enable;
+        options.FullSpread.Filter = setting.Difficulty.IsFullSpread;
 
         if (setting.Bpm.Enable)
         {
@@ -367,7 +365,8 @@ public static class LegacyPresetLoader
             ExcludeTags =
             {
                 Enable = setting.Tags.Exclude.Enable,
-                Filter = setting.Tags.Exclude.Content.ToHashSet()
+                Filter = setting.Tags.Exclude.Content.ToHashSet(),
+                IsOr = !setting.Tags.Exclude.And
             },
             UpVotes = new()
             {

--- a/Libs/BeatSpiderSharp.Models/BeatSaver/Diff.cs
+++ b/Libs/BeatSpiderSharp.Models/BeatSaver/Diff.cs
@@ -22,6 +22,9 @@ public record Diff
     [JsonProperty("nps")]
     public float Nps { get; init; }
 
+    /**
+     * The length of the map in beats.
+     */
     [JsonProperty("length")]
     public float Length { get; init; }
 

--- a/Libs/BeatSpiderSharp.Models/BeatSaver/SongVersion.cs
+++ b/Libs/BeatSpiderSharp.Models/BeatSaver/SongVersion.cs
@@ -13,6 +13,11 @@ public record SongVersion
     [JsonProperty("createdAt")]
     public DateTimeOffset? CreatedAt { get; init; }
 
+    /**
+     * How likely the map is auto generated.
+     * Higher is less likely.
+     * BeatSage maps are usually negative
+     */
     [JsonProperty("sageScore")]
     public int SageScore { get; init; }
 

--- a/Libs/BeatSpiderSharp.Models/BeatSaver/Stats.cs
+++ b/Libs/BeatSpiderSharp.Models/BeatSaver/Stats.cs
@@ -5,9 +5,11 @@ namespace BeatSpiderSharp.Models.BeatSaver;
 public record Stats
 {
     [JsonProperty("plays")]
+    [Obsolete("BeatSaver does not keep track of it")]
     public int Plays { get; init; }
 
     [JsonProperty("downloads")]
+    [Obsolete("BeatSaver does not keep track of it.")]
     public int Downloads { get; init; }
 
     [JsonProperty("upvotes")]

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterConfig.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterConfig.cs
@@ -4,5 +4,7 @@ namespace BeatSpiderSharp.Models.Preset;
 
 public class FilterConfig
 {
-    public DetailOptions DetailFilter { get; set; } = new();
+    public SongDetailOptions SongDetailFilter { get; init; } = new();
+
+    public LevelDetailOptions LevelDetailOptions { get; init; } = new();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
@@ -20,16 +20,34 @@ public class DetailOptions
     public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; set; } = new();
     public LogicIncludeOption<MMod> RequireMods { get; set; } = new();
     public ExcludeOption<MMod> ExcludeMods { get; set; } = new();
+
+    // Doesn't work, BeatSaver do not keep track of download count
+    public RangeOption<int> Downloads { get; set; } = new();
+
+    // Doesn't work, BeatSaver do not keep track of play count
+    public RangeOption<int> Plays { get; set; } = new();
+
+    // Default to only Human maps
+    public Option<bool> AutoMapper { get; set; } = new(false) { Enable = true };
     public RangeOption<float> Bpm { get; set; } = new();
     public RangeOption<int> Duration { get; set; } = new();
+    public RangeOption<float> Seconds { get; set; } = new();
+    public RangeOption<float> Beats { get; set; } = new();
     public RangeOption<float> Njs { get; set; } = new();
+    public RangeOption<float> Offset { get; set; } = new();
     public RangeOption<float> Nps { get; set; } = new();
     public RangeOption<int> Notes { get; set; } = new();
     public RangeOption<int> Bombs { get; set; } = new();
+    public RangeOption<int> Events { get; set; } = new();
     public RangeOption<int> Walls { get; set; } = new();
     public IncludeOption<RankingStatus> ScoreSaberRanking { get; set; } = new();
     public IncludeOption<RankingStatus> BeatLeaderRanking { get; set; } = new();
     public RangeOption<float> ScoreSaberStars { get; set; } = new();
     public RangeOption<float> BeatLeaderStars { get; set; } = new();
+    public RangeOption<int> ParityErrors { get; set; } = new();
+    public RangeOption<int> ParityWarns { get; set; } = new();
+    public RangeOption<int> ParityResets { get; set; } = new();
+    public RangeOption<int> SageScore { get; set; } = new();
+    public RangeOption<int> MaxScore { get; set; } = new();
     public Option Chinese { get; set; } = new();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
@@ -8,14 +8,14 @@ public class DetailOptions
     public IncludeOption<int> UploaderId { get; set; } = new();
     public IncludeOption<string> UploaderName { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
     public RangeOption<DateTimeOffset> UploadTime { get; set; } = new();
-    public LogicIncludeOption<string> IncludeTags { get; set; } = new();
-    public ExcludeOption<string> ExcludeTags { get; set; } = new();
+    public LogicIncludeOption<string> IncludeTags { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
+    public LogicExcludeOption<string> ExcludeTags { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
     public RangeOption<int> UpVotes { get; set; } = new();
     public RangeOption<float> UpVotePercentage { get; set; } = new();
     public RangeOption<int> DownVotes { get; set; } = new();
     public RangeOption<float> DownVotePercentage { get; set; } = new();
     public RangeOption<float> Rating { get; set; } = new();
-    public Option FullSpread { get; set; } = new();
+    public Option<bool> FullSpread { get; set; } = new(true);
     public LogicIncludeOption<MCharacteristic> IncludeCharacteristics { get; set; } = new();
     public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; set; } = new();
     public LogicIncludeOption<MMod> RequireMods { get; set; } = new();

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/DetailOptions.cs
@@ -5,49 +5,49 @@ namespace BeatSpiderSharp.Models.Preset.FilterOptions;
 //TODO separate song and individual difficulty filters
 public class DetailOptions
 {
-    public IncludeOption<int> UploaderId { get; set; } = new();
-    public IncludeOption<string> UploaderName { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
-    public RangeOption<DateTimeOffset> UploadTime { get; set; } = new();
-    public LogicIncludeOption<string> IncludeTags { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
-    public LogicExcludeOption<string> ExcludeTags { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
-    public RangeOption<int> UpVotes { get; set; } = new();
-    public RangeOption<float> UpVotePercentage { get; set; } = new();
-    public RangeOption<int> DownVotes { get; set; } = new();
-    public RangeOption<float> DownVotePercentage { get; set; } = new();
-    public RangeOption<float> Rating { get; set; } = new();
-    public Option<bool> FullSpread { get; set; } = new(true);
-    public LogicIncludeOption<MCharacteristic> IncludeCharacteristics { get; set; } = new();
-    public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; set; } = new();
-    public LogicIncludeOption<MMod> RequireMods { get; set; } = new();
-    public ExcludeOption<MMod> ExcludeMods { get; set; } = new();
+    public IncludeOption<int> UploaderId { get; init; } = new();
+    public IncludeOption<string> UploaderName { get; init; } = new(StringComparer.InvariantCultureIgnoreCase);
+    public RangeOption<DateTimeOffset> UploadTime { get; init; } = new();
+    public LogicIncludeOption<string> IncludeTags { get; init; } = new(StringComparer.InvariantCultureIgnoreCase);
+    public LogicExcludeOption<string> ExcludeTags { get; init; } = new(StringComparer.InvariantCultureIgnoreCase);
+    public RangeOption<int> UpVotes { get; init; } = new();
+    public RangeOption<float> UpVotePercentage { get; init; } = new();
+    public RangeOption<int> DownVotes { get; init; } = new();
+    public RangeOption<float> DownVotePercentage { get; init; } = new();
+    public RangeOption<float> Rating { get; init; } = new();
+    public Option<bool> FullSpread { get; init; } = new(true);
+    public LogicIncludeOption<MCharacteristic> IncludeCharacteristics { get; init; } = new();
+    public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; init; } = new();
+    public LogicIncludeOption<MMod> RequireMods { get; init; } = new();
+    public ExcludeOption<MMod> ExcludeMods { get; init; } = new();
 
     // Doesn't work, BeatSaver do not keep track of download count
-    public RangeOption<int> Downloads { get; set; } = new();
+    public RangeOption<int> Downloads { get; init; } = new();
 
     // Doesn't work, BeatSaver do not keep track of play count
-    public RangeOption<int> Plays { get; set; } = new();
+    public RangeOption<int> Plays { get; init; } = new();
 
     // Default to only Human maps
-    public Option<bool> AutoMapper { get; set; } = new(false) { Enable = true };
-    public RangeOption<float> Bpm { get; set; } = new();
-    public RangeOption<int> Duration { get; set; } = new();
-    public RangeOption<float> Seconds { get; set; } = new();
-    public RangeOption<float> Beats { get; set; } = new();
-    public RangeOption<float> Njs { get; set; } = new();
-    public RangeOption<float> Offset { get; set; } = new();
-    public RangeOption<float> Nps { get; set; } = new();
-    public RangeOption<int> Notes { get; set; } = new();
-    public RangeOption<int> Bombs { get; set; } = new();
-    public RangeOption<int> Events { get; set; } = new();
-    public RangeOption<int> Walls { get; set; } = new();
-    public IncludeOption<RankingStatus> ScoreSaberRanking { get; set; } = new();
-    public IncludeOption<RankingStatus> BeatLeaderRanking { get; set; } = new();
-    public RangeOption<float> ScoreSaberStars { get; set; } = new();
-    public RangeOption<float> BeatLeaderStars { get; set; } = new();
-    public RangeOption<int> ParityErrors { get; set; } = new();
-    public RangeOption<int> ParityWarns { get; set; } = new();
-    public RangeOption<int> ParityResets { get; set; } = new();
-    public RangeOption<int> SageScore { get; set; } = new();
-    public RangeOption<int> MaxScore { get; set; } = new();
-    public Option Chinese { get; set; } = new();
+    public Option<bool> AutoMapper { get; init; } = new(false) { Enable = true };
+    public RangeOption<float> Bpm { get; init; } = new();
+    public RangeOption<int> Duration { get; init; } = new();
+    public RangeOption<float> Seconds { get; init; } = new();
+    public RangeOption<float> Beats { get; init; } = new();
+    public RangeOption<float> Njs { get; init; } = new();
+    public RangeOption<float> Offset { get; init; } = new();
+    public RangeOption<float> Nps { get; init; } = new();
+    public RangeOption<int> Notes { get; init; } = new();
+    public RangeOption<int> Bombs { get; init; } = new();
+    public RangeOption<int> Events { get; init; } = new();
+    public RangeOption<int> Walls { get; init; } = new();
+    public IncludeOption<RankingStatus> ScoreSaberRanking { get; init; } = new();
+    public IncludeOption<RankingStatus> BeatLeaderRanking { get; init; } = new();
+    public RangeOption<float> ScoreSaberStars { get; init; } = new();
+    public RangeOption<float> BeatLeaderStars { get; init; } = new();
+    public RangeOption<int> ParityErrors { get; init; } = new();
+    public RangeOption<int> ParityWarns { get; init; } = new();
+    public RangeOption<int> ParityResets { get; init; } = new();
+    public RangeOption<int> SageScore { get; init; } = new();
+    public RangeOption<int> MaxScore { get; init; } = new();
+    public Option Chinese { get; init; } = new();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/LevelDetailOptions.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/LevelDetailOptions.cs
@@ -1,0 +1,26 @@
+﻿using BeatSpiderSharp.Models.Enums;
+
+namespace BeatSpiderSharp.Models.Preset.FilterOptions;
+
+public class LevelDetailOptions
+{
+    public LogicIncludeOption<MCharacteristic> IncludeCharacteristics { get; init; } = new();
+    public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; init; } = new();
+    public LogicIncludeOption<MMod> RequireMods { get; init; } = new();
+    public ExcludeOption<MMod> ExcludeMods { get; init; } = new();
+    public RangeOption<float> Seconds { get; init; } = new();
+    public RangeOption<float> Beats { get; init; } = new();
+    public RangeOption<float> Njs { get; init; } = new();
+    public RangeOption<float> Offset { get; init; } = new();
+    public RangeOption<float> Nps { get; init; } = new();
+    public RangeOption<int> Notes { get; init; } = new();
+    public RangeOption<int> Bombs { get; init; } = new();
+    public RangeOption<int> Events { get; init; } = new();
+    public RangeOption<int> Walls { get; init; } = new();
+    public RangeOption<float> ScoreSaberStars { get; init; } = new();
+    public RangeOption<float> BeatLeaderStars { get; init; } = new();
+    public RangeOption<int> ParityErrors { get; init; } = new();
+    public RangeOption<int> ParityWarns { get; init; } = new();
+    public RangeOption<int> ParityResets { get; init; } = new();
+    public RangeOption<int> MaxScore { get; init; } = new();
+};

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/Options.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/Options.cs
@@ -27,17 +27,27 @@ public class RangeOption<T> : Option where T : struct, IComparable<T>
 
 public abstract class ValueSetOption<T>(IEqualityComparer<T>? comparer = null)
     : Option<ISet<T>>(new HashSet<T>(comparer));
-
-public class LogicIncludeOption<T>(IEqualityComparer<T>? comparer = null) : ValueSetOption<T>(comparer)
+//TODO Unit tests
+public abstract class LogicSetOption<T>(IEqualityComparer<T>? comparer = null) : ValueSetOption<T>(comparer)
 {
+    [JsonProperty(Order = -79)]
     public bool IsOr { get; set; }
 
-    public bool SatisfiedBy(ICollection<T> values)
-    {
-        var required = Filter;
-        if (required.Count == 0) return true; // vacuously true
-        return IsOr ? required.Overlaps(values) : required.IsSubsetOf(values);
-    }
+    protected bool TestInclude(ICollection<T> values) => IsOr ? Filter.Overlaps(values) : Filter.IsSubsetOf(values);
+
+    protected abstract bool TestLogic(ICollection<T> values);
+
+    public bool SatisfiedBy(ICollection<T> values) => Filter.Count == 0 || TestLogic(values);
+}
+
+public class LogicIncludeOption<T>(IEqualityComparer<T>? comparer = null) : LogicSetOption<T>(comparer)
+{
+    protected override bool TestLogic(ICollection<T> values) => TestInclude(values);
+}
+
+public class LogicExcludeOption<T>(IEqualityComparer<T>? comparer = null) : LogicSetOption<T>(comparer)
+{
+    protected override bool TestLogic(ICollection<T> values) => !TestInclude(values);
 }
 
 /**
@@ -48,6 +58,9 @@ public class IncludeOption<T>(IEqualityComparer<T>? comparer = null) : ValueSetO
     public bool SatisfiedBy(T value) => Filter.Count == 0 || Filter.Contains(value);
 }
 
+/**
+ * Use to test none of the excluded values is present
+ */
 public class ExcludeOption<T>(IEqualityComparer<T>? comparer = null) : ValueSetOption<T>(comparer)
 {
     public bool SatisfiedBy(ICollection<T> values)

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/Options.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/Options.cs
@@ -16,6 +16,13 @@ public class Option<T>(T initialValue) : Option
     public T Filter { get; set; } = initialValue;
 }
 
+public class CollectionOption<TCollection, TValue>(TCollection initialValue)
+    : Option where TCollection : ICollection<TValue>
+{
+    [JsonProperty(Order = -89)]
+    public TCollection Filter { get; init; } = initialValue;
+}
+
 public class RangeOption<T> : Option where T : struct, IComparable<T>
 {
     public T? Min { get; set; }
@@ -26,7 +33,7 @@ public class RangeOption<T> : Option where T : struct, IComparable<T>
 }
 
 public abstract class ValueSetOption<T>(IEqualityComparer<T>? comparer = null)
-    : Option<ISet<T>>(new HashSet<T>(comparer));
+    : CollectionOption<ISet<T>, T>(new HashSet<T>(comparer));
 //TODO Unit tests
 public abstract class LogicSetOption<T>(IEqualityComparer<T>? comparer = null) : ValueSetOption<T>(comparer)
 {

--- a/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/SongDetailOptions.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/FilterOptions/SongDetailOptions.cs
@@ -2,8 +2,7 @@
 
 namespace BeatSpiderSharp.Models.Preset.FilterOptions;
 
-//TODO separate song and individual difficulty filters
-public class DetailOptions
+public class SongDetailOptions
 {
     public IncludeOption<int> UploaderId { get; init; } = new();
     public IncludeOption<string> UploaderName { get; init; } = new(StringComparer.InvariantCultureIgnoreCase);
@@ -16,10 +15,6 @@ public class DetailOptions
     public RangeOption<float> DownVotePercentage { get; init; } = new();
     public RangeOption<float> Rating { get; init; } = new();
     public Option<bool> FullSpread { get; init; } = new(true);
-    public LogicIncludeOption<MCharacteristic> IncludeCharacteristics { get; init; } = new();
-    public LogicIncludeOption<MDifficulty> IncludeDifficulties { get; init; } = new();
-    public LogicIncludeOption<MMod> RequireMods { get; init; } = new();
-    public ExcludeOption<MMod> ExcludeMods { get; init; } = new();
 
     // Doesn't work, BeatSaver do not keep track of download count
     public RangeOption<int> Downloads { get; init; } = new();
@@ -31,23 +26,8 @@ public class DetailOptions
     public Option<bool> AutoMapper { get; init; } = new(false) { Enable = true };
     public RangeOption<float> Bpm { get; init; } = new();
     public RangeOption<int> Duration { get; init; } = new();
-    public RangeOption<float> Seconds { get; init; } = new();
-    public RangeOption<float> Beats { get; init; } = new();
-    public RangeOption<float> Njs { get; init; } = new();
-    public RangeOption<float> Offset { get; init; } = new();
-    public RangeOption<float> Nps { get; init; } = new();
-    public RangeOption<int> Notes { get; init; } = new();
-    public RangeOption<int> Bombs { get; init; } = new();
-    public RangeOption<int> Events { get; init; } = new();
-    public RangeOption<int> Walls { get; init; } = new();
     public IncludeOption<RankingStatus> ScoreSaberRanking { get; init; } = new();
     public IncludeOption<RankingStatus> BeatLeaderRanking { get; init; } = new();
-    public RangeOption<float> ScoreSaberStars { get; init; } = new();
-    public RangeOption<float> BeatLeaderStars { get; init; } = new();
-    public RangeOption<int> ParityErrors { get; init; } = new();
-    public RangeOption<int> ParityWarns { get; init; } = new();
-    public RangeOption<int> ParityResets { get; init; } = new();
     public RangeOption<int> SageScore { get; init; } = new();
-    public RangeOption<int> MaxScore { get; init; } = new();
     public Option Chinese { get; init; } = new();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/InputConfig.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/InputConfig.cs
@@ -6,7 +6,7 @@ public class InputConfig
 {
     public SongInputSource Source { get; set; } = SongInputSource.BeatSaver;
 
-    public IList<string> Playlists { get; set; } = new List<string>();
+    public IList<string> Playlists { get; init; } = new List<string>();
 
-    public IList<string> ManualInput { get; set; } = new List<string>();
+    public IList<string> ManualInput { get; init; } = new List<string>();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/OutputConfig.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/OutputConfig.cs
@@ -18,9 +18,9 @@ public class OutputConfig
 
     public bool SkipExisting { get; set; }
 
-    public IList<string> ExistingSongPaths { get; set; } = new List<string>();
+    public IList<string> ExistingSongPaths { get; init; } = new List<string>();
     
     public bool CopyLocalSongs { get; set; }
-    
-    public IList<string> LocalSongPaths { get; set; } = new List<string>();
+
+    public IList<string> LocalSongPaths { get; init; } = new List<string>();
 }

--- a/Libs/BeatSpiderSharp.Models/Preset/Preset.cs
+++ b/Libs/BeatSpiderSharp.Models/Preset/Preset.cs
@@ -8,12 +8,12 @@ public class Preset
 
     public string Author { get; set; } = string.Empty;
 
-    public InputConfig Input { get; set; } = new InputConfig();
+    public InputConfig Input { get; init; } = new();
 
-    public OutputConfig Output { get; set; } = new OutputConfig();
+    public OutputConfig Output { get; init; } = new();
 
     /// <summary>
     /// Multiple instances applied as OR
     /// </summary>
-    public IList<FilterConfig> FilterOptions { get; set; } = new List<FilterConfig>(1);
+    public IList<FilterConfig> FilterOptions { get; init; } = new List<FilterConfig>(1);
 }


### PR DESCRIPTION
 - Implemented all remaining song filter options from the legacy preset
 - Split DetailOptions into SongDetailOptions and LevelDetailOptions, guaranteeing filtered songs each hasat least one difficulty satisfying all level filters
 - Updated legacy preset conversion logic for merging input settings
 - Fixed several filter logic and legacy conversion bugs
